### PR TITLE
Build on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,10 +46,12 @@ set(SHADERS
 
 add_executable(VulkanPBRT ${SOURCES} ${VSG_ALL} ${BFR_SRC} ${TAA_SRC})
 
-target_link_libraries(VulkanPBRT Vulkan::Vulkan glslang::glslang Threads::Threads ${ASSIMP_LIBRARIES})
+target_link_libraries(VulkanPBRT Vulkan::Vulkan glslang::glslang Threads::Threads)
 if(UNIX)
-    target_link_libraries(VulkanPBRT xcb)
-endif(UNIX)
+    target_link_libraries(VulkanPBRT xcb ${ASSIMP_LIBRARIES})
+elseif(WIN32)
+    target_link_libraries(VulkanPBRT assimp::assimp)
+endif()
 
 ## compilation of shader files
 function(add_shader TARGET SHADER)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,8 +8,7 @@ project(VulkanPBRT
 
 find_package(Vulkan REQUIRED)
 find_package(Threads REQUIRED)
-find_package(PkgConfig)
-pkg_check_modules(xcb REQUIRED IMPORTED_TARGET xcb)
+find_package(assimp CONFIG REQUIRED)
 include(CMakeFindDependencyMacro)
 set(vsg_glslang_DIR ${CMAKE_SOURCE_DIR}/vsg)
 find_dependency(vsg_glslang)
@@ -20,15 +19,13 @@ add_subdirectory(TAA)
 set(IMGUI_HEADER
     vsg/src/imgui/)
 include_directories(vsg/include ${glslang_INCLUDE_DIRS} ${IMGUI_HEADER})
-
 set(CMAKE_CXX_STANDARD 17)
-
 file(GLOB SOURCES
     "*.h"
     "*.hpp"
     "*.cpp"
 )
-
+list(FILTER GLOB EXCLUDE REGEX "${PROJECT_SOURCE_DIR}/vsg/.*" )
 set(SHADERS
     pbr_closesthit.rchit
     miss.rmiss
@@ -49,9 +46,12 @@ set(SHADERS
 
 add_executable(VulkanPBRT ${SOURCES} ${VSG_ALL} ${BFR_SRC} ${TAA_SRC})
 
-target_link_libraries(VulkanPBRT Vulkan::Vulkan glslang::glslang Threads::Threads xcb assimp)
+target_link_libraries(VulkanPBRT Vulkan::Vulkan glslang::glslang Threads::Threads assimp::assimp)
+if(UNIX)
+    target_link_libraries(VulkanPBRT xcb)
+endif(UNIX)
 
-## compilaiton of shader files
+## compilation of shader files
 function(add_shader TARGET SHADER)
     find_program(GLSLC glslc)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ set(SHADERS
 
 add_executable(VulkanPBRT ${SOURCES} ${VSG_ALL} ${BFR_SRC} ${TAA_SRC})
 
-target_link_libraries(VulkanPBRT Vulkan::Vulkan glslang::glslang Threads::Threads assimp::assimp)
+target_link_libraries(VulkanPBRT Vulkan::Vulkan glslang::glslang Threads::Threads ${ASSIMP_LIBRARIES})
 if(UNIX)
     target_link_libraries(VulkanPBRT xcb)
 endif(UNIX)

--- a/CountTrianglesVisitor.hpp
+++ b/CountTrianglesVisitor.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
-#include<vsg/all.h>
+#include "Defines.hpp"
+#include <vsg/all.h>
 
 class CountTrianglesVisitor : public vsg::Visitor
 {

--- a/Defines.hpp
+++ b/Defines.hpp
@@ -1,0 +1,3 @@
+#pragma once
+
+using uint = uint32_t;

--- a/GBuffer.hpp
+++ b/GBuffer.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "Defines.hpp"
 #include <vsg/all.h>
 
 // class holding all references for the gbuffer

--- a/GBufferRasterizer.hpp
+++ b/GBufferRasterizer.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "Defines.hpp"
 #include <vsg/all.h>
 #include "GBuffer.hpp"
 

--- a/IO/IO.hpp
+++ b/IO/IO.hpp
@@ -10,15 +10,16 @@
 
 std::string getUserDirectory() {
 #ifdef __unix__
-    return std::string() + getenv("HOME") + "/";
+	return std::string() + getenv("HOME") + "/";
 #else
-    // Use WinAPI to query the user directory.
-    char userDirPath[MAX_PATH];
-    SHGetSpecialFolderPathA(NULL, userDirPath, CSIDL_PROFILE, true);
-    std::string userDir = std::string() + userDirPath + "/";
-    for (std::string::iterator it = dir.begin(); it != dir.end(); ++it) {
-        if (*it == '\\') *it = '/';
-    }
-    return userDir;
+	// Use WinAPI to query the user directory.
+	WCHAR path[MAX_PATH + 1];
+	if (SHGetSpecialFolderPathW(NULL, path, CSIDL_PROFILE, FALSE)) {
+		std::wstring ws(path);
+		std::string str(ws.begin(), ws.end());
+		return str + '/';
+	} else { 
+		return NULL;
+	}
 #endif
 }

--- a/IlluminationBuffer.hpp
+++ b/IlluminationBuffer.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "Defines.hpp"
 #include <vsg/all.h>
 #include <assert.h>
 

--- a/PBRTPipeline.hpp
+++ b/PBRTPipeline.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "Defines.hpp"
 #include <vsg/all.h>
 #include "GBuffer.hpp"
 #include "IlluminationBuffer.hpp"

--- a/PipelineStructs.hpp
+++ b/PipelineStructs.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "Defines.hpp"
 #include <vsg/all.h>
 
 struct RayTracingPushConstants{

--- a/RayTracingVisitor.hpp
+++ b/RayTracingVisitor.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "Defines.hpp"
 #include <vsg/all.h>
 #include <vector>
 #include "PipelineStructs.hpp"

--- a/VulkanPBRT.cpp
+++ b/VulkanPBRT.cpp
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <set>
+#include "Defines.hpp"
 #include <vsg/all.h>
 #include <vsgXchange/models.h>
 #include <vsgXchange/images.h>

--- a/gui.hpp
+++ b/gui.hpp
@@ -3,7 +3,7 @@
 #include <vsgImGui/RenderImGui.h>
 #include <vsgImGui/SendEventsToImGui.h>
 #include <imgui.h>
-
+#include "Defines.hpp"
 #include <vsg/all.h>
 
 class Gui{

--- a/vsg/CMakeLists.txt
+++ b/vsg/CMakeLists.txt
@@ -1,5 +1,4 @@
 # cmake file to get all src files for compilation and to add include to include directories
-
 file(GLOB_RECURSE VSG_SRC src/
     *.cpp
     +.h
@@ -16,17 +15,24 @@ file(GLOB IMGUI_SRC src/imgui/imgui.cpp
 file(GLOB ANDROID_PLATFORM src/vsg/platform/android/Android_Window.cpp)
 file(GLOB MAC_PLATFORM src/vsg/platform/macos/MacOS_Window.mm)
 file(GLOB WIN_PLATFORM src/vsg/platform/win32/Win32_Window.cpp)
-file(GLOB UINX_PLATFORM src/vsg/platform/unix/Xcb_Window.cpp)
-
+file(GLOB UNIX_PLATFORM src/vsg/platform/unix/Xcb_Window.cpp)
+include(src/vsgXchange/assimp/build_vars.cmake)
 #exclude wrong platfrom things
 if (ANDROID)
-    list(REMOVE_ITEM VSG_SRC "${MAC_PLATFORM}${WIN_PLATFORM}${UINX_PLATFORM}")
-
+    list(REMOVE_ITEM VSG_SRC "${MAC_PLATFORM}")
+    list(REMOVE_ITEM VSG_SRC "${UNIX_PLATFORM}")
+    list(REMOVE_ITEM VSG_SRC "${WIN_PLATFORM}")
 elseif (WIN32)
-    list(REMOVE_ITEM VSG_SRC "${MAC_PLATFORM}${ANDROID_PLATFORM}${UINX_PLATFORM}")
+    list(REMOVE_ITEM VSG_SRC "${MAC_PLATFORM}")
+    list(REMOVE_ITEM VSG_SRC "${UNIX_PLATFORM}")
+    list(REMOVE_ITEM VSG_SRC "${ANDROID_PLATFORM}")
 elseif (APPLE)
-    list(REMOVE_ITEM VSG_SRC "${ANDROID_PLATFORM}${WIN_PLATFORM}${UINX_PLATFORM}")
+     list(REMOVE_ITEM VSG_SRC "${ANDROID_PLATFORM}")
+    list(REMOVE_ITEM VSG_SRC "${UNIX_PLATFORM}")
+    list(REMOVE_ITEM VSG_SRC "${WIN_PLATFORM}")
 else()
+	find_package(PkgConfig)
+	pkg_check_modules(xcb REQUIRED IMPORTED_TARGET xcb)
     list(REMOVE_ITEM VSG_SRC "${MAC_PLATFORM}")
     list(REMOVE_ITEM VSG_SRC "${WIN_PLATFORM}")
     list(REMOVE_ITEM VSG_SRC "${ANDROID_PLATFORM}")

--- a/vsg/src/vsgXchange/assimp/build_vars.cmake
+++ b/vsg/src/vsgXchange/assimp/build_vars.cmake
@@ -1,19 +1,20 @@
 # add assimp if vailable
-find_package(assimp 5.0.0)
+# TODO: Decide whether to keep this file, also test on Linux
+#find_package(assimp 5.0.0)
 
-if(assimp_FOUND)
-    OPTION(vsgXchange_assimp "Optional Assimp support provided" ON)
-endif()
+#if(assimp_FOUND)
+#    OPTION(vsgXchange_assimp "Optional Assimp support provided" ON)
+#endif()
 
-if (${vsgXchange_assimp})
-    set(SOURCES ${SOURCES}
-        assimp/assimp.cpp
-    )
-    set(EXTRA_INCLUDES ${EXTRA_INCLUDES} ${assimp_INCLUDE_DIRS})
-    set(EXTRA_LIBRARIES ${EXTRA_LIBRARIES} assimp::assimp)
-    set(FIND_DEPENDENCY ${FIND_DEPENDENCY} "find_dependency(assimp)")
-else()
-    set(SOURCES ${SOURCES}
-        assimp/assimp_fallback.cpp
-    )
-endif()
+#if (${vsgXchange_assimp})
+#    set(SOURCES ${SOURCES}
+#        assimp/assimp.cpp
+#    )
+#    set(EXTRA_INCLUDES ${EXTRA_INCLUDES} ${assimp_INCLUDE_DIRS})
+#    set(EXTRA_LIBRARIES ${EXTRA_LIBRARIES} assimp::assimp)
+#    set(FIND_DEPENDENCY ${FIND_DEPENDENCY} "find_dependency(assimp)")
+#else()
+#    set(SOURCES ${SOURCES}
+#        assimp/assimp_fallback.cpp
+#    )
+#endif()


### PR DESCRIPTION
This possibly fixes #1 . I managed to get it build on Windows but testing on Linux is also necessary. I think it would be great to have it portable while the project is in early stages. I also added a `Defines.hpp` because apparently `uint` type is defined to `uint32_t` in xcb and the project itself uses `uint` type.