### PR TITLE
Multiple minor updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,7 @@ build/
 # CLion
 .idea/*
 cmake-build-*/
+
+# visual studio files
+.vs/
+CMakeSettings.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ file(GLOB SOURCES
     "*.hpp"
     "*.cpp"
 )
-list(FILTER GLOB EXCLUDE REGEX "${PROJECT_SOURCE_DIR}/vsg/.*" )
+list(FILTER SOURCES EXCLUDE REGEX "${PROJECT_SOURCE_DIR}/vsg/.*" )
 set(SHADERS
     pbr_closesthit.rchit
     miss.rmiss

--- a/VulkanPBRT.cpp
+++ b/VulkanPBRT.cpp
@@ -44,18 +44,18 @@ DenoisingBlockSize denoisingBlockSize = DenoisingBlockSize::x32;
 class LoggingRedirectSentry
 {
 public:
-	LoggingRedirectSentry(std::ostream* outStream, std::streambuf* originalBuffer)
-		: outStream(outStream), originalBuffer(originalBuffer)
-	{
-	}
-	~LoggingRedirectSentry()
-	{
-		//reset to standard output
-		outStream->rdbuf(originalBuffer); 
-	}
+    LoggingRedirectSentry(std::ostream* outStream, std::streambuf* originalBuffer)
+    	: outStream(outStream), originalBuffer(originalBuffer)
+    {
+    }
+    ~LoggingRedirectSentry()
+    {
+        //reset to standard output
+        outStream->rdbuf(originalBuffer); 
+    }
 private:
-	std::ostream* outStream;
-	std::streambuf* originalBuffer;
+    std::ostream* outStream;
+    std::streambuf* originalBuffer;
 };
 
 int main(int argc, char** argv){
@@ -63,19 +63,19 @@ int main(int argc, char** argv){
         // command line parsing
         vsg::CommandLine arguments(&argc, argv);
 
-		std::ofstream out("out_log.txt");
-		std::streambuf *coutBuf = std::cout.rdbuf();
-		std::ofstream err_log("err_log.txt");
-		std::streambuf *cerrBuf = std::cerr.rdbuf();
-		if (arguments.read({ "--log", "-l" }))
-		{
-			// redirect cout and cerr to log files
-			std::cout.rdbuf(out.rdbuf());
-			std::cerr.rdbuf(err_log.rdbuf());
-		}
-    	// ensure that cout and cerr are reset to their standard output when main() is exited
-		LoggingRedirectSentry coutSentry(&std::cout, coutBuf);
-		LoggingRedirectSentry cerrSenry(&std::cerr, cerrBuf);
+        std::ofstream out("out_log.txt");
+        std::streambuf *coutBuf = std::cout.rdbuf();
+        std::ofstream err_log("err_log.txt");
+        std::streambuf *cerrBuf = std::cerr.rdbuf();
+        if (arguments.read({ "--log", "-l" }))
+        {
+            // redirect cout and cerr to log files
+            std::cout.rdbuf(out.rdbuf());
+            std::cerr.rdbuf(err_log.rdbuf());
+        }
+        // ensure that cout and cerr are reset to their standard output when main() is exited
+        LoggingRedirectSentry coutSentry(&std::cout, coutBuf);
+        LoggingRedirectSentry cerrSenry(&std::cerr, cerrBuf);
 		
 
         auto windowTraits = vsg::WindowTraits::create();
@@ -88,10 +88,10 @@ int main(int argc, char** argv){
 
         auto numFrames = arguments.value(-1, "-f");
         auto filename = arguments.value(std::string(), "-i");
-		if (filename.empty())
-		{
-			std::cout << "Missing input parameter \"-i <path_to_model>\"." << std::endl;
-		}
+        if (filename.empty())
+        {
+            std::cout << "Missing input parameter \"-i <path_to_model>\"." << std::endl;
+        }
         if(arguments.read("m")) filename = "models/raytracing_scene.vsgt";
         if(arguments.errors()) return arguments.writeErrorMessages(std::cerr);
 

--- a/VulkanPBRT.cpp
+++ b/VulkanPBRT.cpp
@@ -94,8 +94,7 @@ int main(int argc, char** argv){
 #ifdef _DEBUG
         // overwriting command line options for debug
         windowTraits->debugLayer = true;
-        windowTraits->width = 1800;
-        filename = getUserDirectory() + "Downloads/glTF-Sample-Models-master/2.0/Sponza/glTF/Sponza.gltf";//"/Downloads/teapot.obj";
+		windowTraits->width = 1800;
 #endif
 
         //viewer creation
@@ -268,7 +267,7 @@ int main(int argc, char** argv){
         // -------------------------------------------------------------------------------------
         // creation of scene graph for ray tracing
         // -------------------------------------------------------------------------------------
-        guiValues->raysPerPixel = maxRecursionDepth * 2; //for each depth recursion one next event estimate is done
+        guiValues->raysPerPixel = maxRecursionDepth; //for each depth recursion one next event estimate is done
 
         //state group to bind the pipeline and descriptorset
         auto scenegraph = vsg::Commands::create();


### PR DESCRIPTION
- Fixed cmake error when using Visual Studio 2017
- Added option to write `cout` and `cerr` to files
- Made input scene parameter `-i` mandatory since the the default triangle caused an exception