### PR TITLE
External exr buffer images

### DIFF
--- a/GBuffer.cpp
+++ b/GBuffer.cpp
@@ -90,7 +90,7 @@ void GBuffer::setupImages()
 
     image = vsg::Image::create();
     image->imageType = VK_IMAGE_TYPE_2D;
-    image->format = VK_FORMAT_R32_SFLOAT;
+    image->format = VK_FORMAT_R8G8B8A8_UNORM;
     image->extent.width = width;
     image->extent.height = height;
     image->extent.depth = 1;

--- a/IlluminationBuffer.cpp
+++ b/IlluminationBuffer.cpp
@@ -292,3 +292,30 @@ void IlluminationBufferDemodulatedFloat::fillImages()
     imageInfo = {nullptr, imageView, VK_IMAGE_LAYOUT_GENERAL};
     illuminationImages.push_back(vsg::DescriptorImage::create(imageInfo, 0, 0, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE));
 }
+
+IlluminatonBufferFinalFloat::IlluminatonBufferFinalFloat(uint32_t width, uint32_t height) 
+{
+    this->width = width;
+    this->height = height;
+    illuminationBindings.push_back("outputImage");
+    fillImages();
+}
+
+void IlluminatonBufferFinalFloat::fillImages(){
+    auto image = vsg::Image::create();
+    image->imageType = VK_IMAGE_TYPE_2D;
+    image->format = VK_FORMAT_R32G32B32A32_SFLOAT;
+    image->extent.width = width;
+    image->extent.height = height;
+    image->extent.depth = 1;
+    image->mipLevels = 1;
+    image->arrayLayers = 1;
+    image->samples = VK_SAMPLE_COUNT_1_BIT;
+    image->tiling = VK_IMAGE_TILING_OPTIMAL;
+    image->usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_STORAGE_BIT;
+    image->initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    image->sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+    auto imageView = vsg::ImageView::create(image, VK_IMAGE_ASPECT_COLOR_BIT);
+    vsg::ImageInfo imageInfo{nullptr, imageView, VK_IMAGE_LAYOUT_GENERAL};
+    illuminationImages.push_back(vsg::DescriptorImage::create(imageInfo, 0, 0, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE));
+}

--- a/IlluminationBuffer.hpp
+++ b/IlluminationBuffer.hpp
@@ -61,3 +61,10 @@ public:
 
     void fillImages();
 };
+
+class IlluminatonBufferFinalFloat: public vsg::Inherit<IlluminationBuffer, IlluminatonBufferFinalFloat>{
+public:
+    IlluminatonBufferFinalFloat(uint32_t width, uint32_t height);
+
+    void fillImages();
+};

--- a/PBRTPipeline.cpp
+++ b/PBRTPipeline.cpp
@@ -178,25 +178,21 @@ vsg::ref_ptr<vsg::ShaderStage> PBRTPipeline::setupRaygenShader(std::string rayge
             defines.push_back("FINAL_IMAGE");
             defines.push_back("DEMOD_ILLUMINATION");
             defines.push_back("DEMOD_ILLUMINATION_SQUARED");
-            if (gBuffer)
-                defines.push_back("GBUFFER");
-            if (accumulationBuffer)
-                defines.push_back("PREV_GBUFFER");
         }
         else if (illuminationBuffer.cast<IlluminationBufferDemodulated>())
         {
             defines.push_back("DEMOD_ILLUMINATION");
             defines.push_back("DEMOD_ILLUMINATION_SQUARED");
-            if (gBuffer)
-                defines.push_back("GBUFFER");
-            if (accumulationBuffer)
-                defines.push_back("PREV_GBUFFER");
         }
         else
         {
             throw vsg::Exception{"Error: PBRTPipeline::setupRaygenShader(...) Illumination buffer not supported."};
         }
     }
+    if (gBuffer)
+        defines.push_back("GBUFFER");
+    if (accumulationBuffer)
+        defines.push_back("PREV_GBUFFER");
 
     auto options = vsg::Options::create(vsgXchange::glsl::create());
     auto raygenShader = vsg::ShaderStage::read(VK_SHADER_STAGE_RAYGEN_BIT_KHR, "main", raygenPath, options);

--- a/PBRTPipeline.cpp
+++ b/PBRTPipeline.cpp
@@ -162,12 +162,9 @@ vsg::ref_ptr<vsg::ShaderStage> PBRTPipeline::setupRaygenShader(std::string rayge
     }
     else
     {
-        if (illuminationBuffer.cast<IlluminationBufferFinal>())
+        if (illuminationBuffer.cast<IlluminatonBufferFinalFloat>())
         {
             defines.push_back("FINAL_IMAGE");
-        }
-        else if (illuminationBuffer.cast<IlluminatonBufferFinalFloat>()){
-            defines.push_back("FINAL_IMAGE_HQ");
         }
         else if (illuminationBuffer.cast<IlluminationBufferFinalDirIndir>())
         {

--- a/RayTracingVisitor.cpp
+++ b/RayTracingVisitor.cpp
@@ -328,132 +328,126 @@ void RayTracingSceneDescriptorCreationVisitor::apply(const vsg::Light& l)
 {
     packedLights.push_back(l.getPacked());
 }
-vsg::ref_ptr<vsg::BindDescriptorSet> RayTracingSceneDescriptorCreationVisitor::getBindDescriptorSet(
-    vsg::ref_ptr<vsg::PipelineLayout> pipelineLayout, const vsg::BindingMap& bindingMap)
+void RayTracingSceneDescriptorCreationVisitor::updateDescriptor(vsg::BindDescriptorSet* descSet, const vsg::BindingMap& bindingMap)    
 {
-    if (!_bindDescriptor)
+    if (packedLights.empty())
     {
-        if (packedLights.empty())
-        {
-            std::cout << "Adding default directional light for raytracing" << std::endl;
-            vsg::Light l;
-            l.radius = 0;
-            l.type = vsg::LightSourceType::Directional;
-            vsg::vec3 col{2.f, 2.f, 2.f};
-            l.colorAmbient = col;
-            l.colorDiffuse = col;
-            l.colorSpecular = {0, 0, 0};
-            l.strengths = vsg::vec3(.5f, .0f, .0f);
-            l.dir = vsg::normalize(vsg::vec3(0.1f, 1, -5.1f));
-            packedLights.push_back(l.getPacked());
-        }
-        if (!_lights)
-        {
-            auto lights = vsg::Array<vsg::Light::PackedLight>::create(packedLights.size());
-            std::copy(packedLights.begin(), packedLights.end(), lights->data());
-            _lights = vsg::DescriptorBuffer::create(lights, 12, 0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
-        }
-        if (!_materials)
-        {
-            auto materials = vsg::Array<WaveFrontMaterialPacked>::create(_materialArray.size());
-            std::copy(_materialArray.begin(), _materialArray.end(), materials->data());
-            _materials = vsg::DescriptorBuffer::create(materials, 13, 0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
-        }
-        if (!_instances)
-        {
-            auto instances = vsg::Array<ObjectInstance>::create(_instancesArray.size());
-            std::copy(_instancesArray.begin(), _instancesArray.end(), instances->data());
-            _instances = vsg::DescriptorBuffer::create(instances, 14, 0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
-        }
-
-        // setting the descriptor amount for the object arrays
-        vsg::DescriptorSetLayoutBindings& bindings = pipelineLayout->setLayouts[0]->bindings;
-        int posInd = vsg::ShaderStage::getSetBindingIndex(bindingMap, "Pos").second;
-        std::find_if(bindings.begin(), bindings.end(), [&](VkDescriptorSetLayoutBinding& b) { return b.binding == posInd; })->
-            descriptorCount = static_cast<uint32_t>(_positions.size());
-        int norInd = vsg::ShaderStage::getSetBindingIndex(bindingMap, "Nor").second;
-        std::find_if(bindings.begin(), bindings.end(), [&](VkDescriptorSetLayoutBinding& b) { return b.binding == norInd; })->
-            descriptorCount = static_cast<uint32_t>(_normals.size());
-        int texInd = vsg::ShaderStage::getSetBindingIndex(bindingMap, "Tex").second;
-        std::find_if(bindings.begin(), bindings.end(), [&](VkDescriptorSetLayoutBinding& b) { return b.binding == texInd; })->
-            descriptorCount = static_cast<uint32_t>(_texCoords.size());
-        int indInd = vsg::ShaderStage::getSetBindingIndex(bindingMap, "Ind").second;
-        std::find_if(bindings.begin(), bindings.end(), [&](VkDescriptorSetLayoutBinding& b) { return b.binding == indInd; })->
-            descriptorCount = static_cast<uint32_t>(_indices.size());
-        int diffuseInd = vsg::ShaderStage::getSetBindingIndex(bindingMap, "diffuseMap").second;
-        std::find_if(bindings.begin(), bindings.end(), [&](VkDescriptorSetLayoutBinding& b) { return b.binding == diffuseInd; })->
-            descriptorCount = static_cast<uint32_t>(_diffuse.size());
-        int mrInd = vsg::ShaderStage::getSetBindingIndex(bindingMap, "mrMap").second;
-        std::find_if(bindings.begin(), bindings.end(), [&](VkDescriptorSetLayoutBinding& b) { return b.binding == mrInd; })->descriptorCount
-            = static_cast<uint32_t>(_mr.size());
-        int normalInd = vsg::ShaderStage::getSetBindingIndex(bindingMap, "normalMap").second;
-        std::find_if(bindings.begin(), bindings.end(), [&](VkDescriptorSetLayoutBinding& b) { return b.binding == normalInd; })->
-            descriptorCount = static_cast<uint32_t>(_normal.size());
-        int emissiveInd = vsg::ShaderStage::getSetBindingIndex(bindingMap, "emissiveMap").second;
-        std::find_if(bindings.begin(), bindings.end(), [&](VkDescriptorSetLayoutBinding& b) { return b.binding == emissiveInd; })->
-            descriptorCount = static_cast<uint32_t>(_emissive.size());
-        int specularInd = vsg::ShaderStage::getSetBindingIndex(bindingMap, "specularMap").second;
-        std::find_if(bindings.begin(), bindings.end(), [&](VkDescriptorSetLayoutBinding& b) { return b.binding == specularInd; })->
-            descriptorCount = static_cast<uint32_t>(_specular.size());
-        int lightInd = vsg::ShaderStage::getSetBindingIndex(bindingMap, "Lights").second;
-        int matInd = vsg::ShaderStage::getSetBindingIndex(bindingMap, "Materials").second;
-        int instancesInd = vsg::ShaderStage::getSetBindingIndex(bindingMap, "Instances").second;
-
-        //adding all descriptors and updating their binding
-        vsg::Descriptors descList;
-        for (auto& d : _diffuse)
-        {
-            d->dstBinding = diffuseInd;
-            descList.push_back(d);
-        }
-        for (auto& d : _mr)
-        {
-            d->dstBinding = mrInd;
-            descList.push_back(d);
-        }
-        for (auto& d : _normal)
-        {
-            d->dstBinding = normalInd;
-            descList.push_back(d);
-        }
-        for (auto& d : _emissive)
-        {
-            d->dstBinding = emissiveInd;
-            descList.push_back(d);
-        }
-        for (auto& d : _specular)
-        {
-            d->dstBinding = specularInd;
-            descList.push_back(d);
-        }
-        _lights->dstBinding = lightInd;
-        _materials->dstBinding = matInd;
-        _instances->dstBinding = instancesInd;
-        descList.push_back(_lights);
-        descList.push_back(_materials);
-        descList.push_back(_instances);
-        for (auto& d : _positions)
-        {
-            d->dstBinding = posInd;
-            descList.push_back(d);
-        }
-        for (auto& d : _normals)
-        {
-            d->dstBinding = norInd;
-            descList.push_back(d);
-        }
-        for (auto& d : _texCoords)
-        {
-            d->dstBinding = texInd;
-            descList.push_back(d);
-        }
-        for (auto& d : _indices)
-        {
-            d->dstBinding = indInd;
-            descList.push_back(d);
-        }
-        _descriptorSet = vsg::DescriptorSet::create(pipelineLayout->setLayouts[0], descList);
-        _bindDescriptor = vsg::BindDescriptorSet::create(VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipelineLayout, 0, _descriptorSet);
+        std::cout << "Adding default directional light for raytracing" << std::endl;
+        vsg::Light l;
+        l.radius = 0;
+        l.type = vsg::LightSourceType::Directional;
+        vsg::vec3 col{2.f, 2.f, 2.f};
+        l.colorAmbient = col;
+        l.colorDiffuse = col;
+        l.colorSpecular = {0, 0, 0};
+        l.strengths = vsg::vec3(.5f, .0f, .0f);
+        l.dir = vsg::normalize(vsg::vec3(0.1f, 1, -5.1f));
+        packedLights.push_back(l.getPacked());
     }
-    return _bindDescriptor;
+    if (!_lights)
+    {
+        auto lights = vsg::Array<vsg::Light::PackedLight>::create(packedLights.size());
+        std::copy(packedLights.begin(), packedLights.end(), lights->data());
+        _lights = vsg::DescriptorBuffer::create(lights, 12, 0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
+    }
+    if (!_materials)
+    {
+        auto materials = vsg::Array<WaveFrontMaterialPacked>::create(_materialArray.size());
+        std::copy(_materialArray.begin(), _materialArray.end(), materials->data());
+        _materials = vsg::DescriptorBuffer::create(materials, 13, 0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
+    }
+    if (!_instances)
+    {
+        auto instances = vsg::Array<ObjectInstance>::create(_instancesArray.size());
+        std::copy(_instancesArray.begin(), _instancesArray.end(), instances->data());
+        _instances = vsg::DescriptorBuffer::create(instances, 14, 0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
+    }
+
+    // setting the descriptor amount for the object arrays
+    vsg::DescriptorSetLayoutBindings& bindings = descSet->descriptorSet->setLayout->bindings;
+    int posInd = vsg::ShaderStage::getSetBindingIndex(bindingMap, "Pos").second;
+    std::find_if(bindings.begin(), bindings.end(), [&](VkDescriptorSetLayoutBinding& b) { return b.binding == posInd; })->
+        descriptorCount = static_cast<uint32_t>(_positions.size());
+    int norInd = vsg::ShaderStage::getSetBindingIndex(bindingMap, "Nor").second;
+    std::find_if(bindings.begin(), bindings.end(), [&](VkDescriptorSetLayoutBinding& b) { return b.binding == norInd; })->
+        descriptorCount = static_cast<uint32_t>(_normals.size());
+    int texInd = vsg::ShaderStage::getSetBindingIndex(bindingMap, "Tex").second;
+    std::find_if(bindings.begin(), bindings.end(), [&](VkDescriptorSetLayoutBinding& b) { return b.binding == texInd; })->
+        descriptorCount = static_cast<uint32_t>(_texCoords.size());
+    int indInd = vsg::ShaderStage::getSetBindingIndex(bindingMap, "Ind").second;
+    std::find_if(bindings.begin(), bindings.end(), [&](VkDescriptorSetLayoutBinding& b) { return b.binding == indInd; })->
+        descriptorCount = static_cast<uint32_t>(_indices.size());
+    int diffuseInd = vsg::ShaderStage::getSetBindingIndex(bindingMap, "diffuseMap").second;
+    std::find_if(bindings.begin(), bindings.end(), [&](VkDescriptorSetLayoutBinding& b) { return b.binding == diffuseInd; })->
+        descriptorCount = static_cast<uint32_t>(_diffuse.size());
+    int mrInd = vsg::ShaderStage::getSetBindingIndex(bindingMap, "mrMap").second;
+    std::find_if(bindings.begin(), bindings.end(), [&](VkDescriptorSetLayoutBinding& b) { return b.binding == mrInd; })->descriptorCount
+        = static_cast<uint32_t>(_mr.size());
+    int normalInd = vsg::ShaderStage::getSetBindingIndex(bindingMap, "normalMap").second;
+    std::find_if(bindings.begin(), bindings.end(), [&](VkDescriptorSetLayoutBinding& b) { return b.binding == normalInd; })->
+        descriptorCount = static_cast<uint32_t>(_normal.size());
+    int emissiveInd = vsg::ShaderStage::getSetBindingIndex(bindingMap, "emissiveMap").second;
+    std::find_if(bindings.begin(), bindings.end(), [&](VkDescriptorSetLayoutBinding& b) { return b.binding == emissiveInd; })->
+        descriptorCount = static_cast<uint32_t>(_emissive.size());
+    int specularInd = vsg::ShaderStage::getSetBindingIndex(bindingMap, "specularMap").second;
+    std::find_if(bindings.begin(), bindings.end(), [&](VkDescriptorSetLayoutBinding& b) { return b.binding == specularInd; })->
+        descriptorCount = static_cast<uint32_t>(_specular.size());
+    int lightInd = vsg::ShaderStage::getSetBindingIndex(bindingMap, "Lights").second;
+    int matInd = vsg::ShaderStage::getSetBindingIndex(bindingMap, "Materials").second;
+    int instancesInd = vsg::ShaderStage::getSetBindingIndex(bindingMap, "Instances").second;
+
+    //adding all descriptors and updating their binding
+    vsg::Descriptors descList;
+    for (auto& d : _diffuse)
+    {
+        d->dstBinding = diffuseInd;
+        descList.push_back(d);
+    }
+    for (auto& d : _mr)
+    {
+        d->dstBinding = mrInd;
+        descList.push_back(d);
+    }
+    for (auto& d : _normal)
+    {
+        d->dstBinding = normalInd;
+        descList.push_back(d);
+    }
+    for (auto& d : _emissive)
+    {
+        d->dstBinding = emissiveInd;
+        descList.push_back(d);
+    }
+    for (auto& d : _specular)
+    {
+        d->dstBinding = specularInd;
+        descList.push_back(d);
+    }
+    _lights->dstBinding = lightInd;
+    _materials->dstBinding = matInd;
+    _instances->dstBinding = instancesInd;
+    descList.push_back(_lights);
+    descList.push_back(_materials);
+    descList.push_back(_instances);
+    for (auto& d : _positions)
+    {
+        d->dstBinding = posInd;
+        descList.push_back(d);
+    }
+    for (auto& d : _normals)
+    {
+        d->dstBinding = norInd;
+        descList.push_back(d);
+    }
+    for (auto& d : _texCoords)
+    {
+        d->dstBinding = texInd;
+        descList.push_back(d);
+    }
+    for (auto& d : _indices)
+    {
+        d->dstBinding = indInd;
+        descList.push_back(d);
+    }
+    descSet->descriptorSet->descriptors = descList;
 }

--- a/RayTracingVisitor.hpp
+++ b/RayTracingVisitor.hpp
@@ -26,8 +26,7 @@ public:
     //getting the lights in the scene
     void apply(const vsg::Light& l);
 
-    vsg::ref_ptr<vsg::BindDescriptorSet> getBindDescriptorSet(vsg::ref_ptr<vsg::PipelineLayout> pipelineLayout,
-                                                              const vsg::BindingMap& bindingMap);;
+    void updateDescriptor(vsg::BindDescriptorSet* descSet, const vsg::BindingMap& bindingMap);
 
     //holds the binding command for the raytracing decriptor
     std::vector<vsg::Light::PackedLight> packedLights;
@@ -73,9 +72,6 @@ protected:
     };
     vsg::ref_ptr<vsg::DescriptorBuffer> _instances;
     std::vector<ObjectInstance> _instancesArray;
-    vsg::ref_ptr<vsg::DescriptorSetLayout> _descriptorSetLayout;
-    vsg::ref_ptr<vsg::BindDescriptorSet> _bindDescriptor;
-    vsg::ref_ptr<vsg::DescriptorSet> _descriptorSet;
     //images are available correctly for every instance
     std::vector<vsg::ref_ptr<vsg::DescriptorImage>> _diffuse;
     std::vector<vsg::ref_ptr<vsg::DescriptorImage>> _mr;

--- a/RenderIO.cpp
+++ b/RenderIO.cpp
@@ -345,7 +345,7 @@ void OfflineIllumination::downloadFromIlluminationBufferCommand(vsg::ref_ptr<Ill
         copy->srcImage = info.imageView->image;
         copy->srcImageLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
         copy->dstBuffer = noisyStaging.buffer;
-        copy->regions = {VkBufferImageCopy{0, 0, 0, VkImageSubresourceLayers{VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1}, VkOffset3D{0,0,0}, info.imageView->image->extent}};
+        copy->regions = {VkBufferImageCopy{noisyStaging.offset, 0, 0, VkImageSubresourceLayers{VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1}, VkOffset3D{0,0,0}, info.imageView->image->extent}};
         commands->addChild(copy);
         // transfer image layout back
         memBarrier = vsg::ImageMemoryBarrier::create(VK_ACCESS_NONE_KHR, VK_ACCESS_SHADER_WRITE_BIT,VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, 
@@ -553,7 +553,7 @@ void OfflineGBuffer::downloadFromGBufferCommand(vsg::ref_ptr<GBuffer>& gBuffer, 
         copy->srcImage = info.imageView->image;
         copy->srcImageLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
         copy->dstBuffer = depthStaging.buffer;
-        copy->regions = {VkBufferImageCopy{0,0, 0, VkImageSubresourceLayers{VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1}, VkOffset3D{0,0,0}, info.imageView->image->extent}};
+        copy->regions = {VkBufferImageCopy{depthStaging.offset,0, 0, VkImageSubresourceLayers{VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1}, VkOffset3D{0,0,0}, info.imageView->image->extent}};
         commands->addChild(copy);
         // transfer image layout back
         memBarrier = vsg::ImageMemoryBarrier::create(VK_ACCESS_NONE_KHR, VK_ACCESS_SHADER_WRITE_BIT,VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, 
@@ -580,7 +580,7 @@ void OfflineGBuffer::downloadFromGBufferCommand(vsg::ref_ptr<GBuffer>& gBuffer, 
         copy->srcImage = info.imageView->image;
         copy->srcImageLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
         copy->dstBuffer = normalStaging.buffer;
-        copy->regions = {VkBufferImageCopy{0, 0, 0, VkImageSubresourceLayers{VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1}, VkOffset3D{0,0,0}, info.imageView->image->extent}};
+        copy->regions = {VkBufferImageCopy{normalStaging.offset, 0, 0, VkImageSubresourceLayers{VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1}, VkOffset3D{0,0,0}, info.imageView->image->extent}};
         commands->addChild(copy);
         // transfer image layout back
         memBarrier = vsg::ImageMemoryBarrier::create(VK_ACCESS_NONE_KHR, VK_ACCESS_SHADER_WRITE_BIT,VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, 
@@ -607,7 +607,7 @@ void OfflineGBuffer::downloadFromGBufferCommand(vsg::ref_ptr<GBuffer>& gBuffer, 
         copy->srcImage = info.imageView->image;
         copy->srcImageLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
         copy->dstBuffer = albedoStaging.buffer;
-        copy->regions = {VkBufferImageCopy{0, 0, 0, VkImageSubresourceLayers{VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1}, VkOffset3D{0,0,0}, info.imageView->image->extent}};
+        copy->regions = {VkBufferImageCopy{albedoStaging.offset, 0, 0, VkImageSubresourceLayers{VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1}, VkOffset3D{0,0,0}, info.imageView->image->extent}};
         commands->addChild(copy);
         // transfer image layout back
         memBarrier = vsg::ImageMemoryBarrier::create(VK_ACCESS_NONE_KHR, VK_ACCESS_SHADER_WRITE_BIT,VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, 
@@ -634,7 +634,7 @@ void OfflineGBuffer::downloadFromGBufferCommand(vsg::ref_ptr<GBuffer>& gBuffer, 
         copy->srcImage = info.imageView->image;
         copy->srcImageLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
         copy->dstBuffer = materialStaging.buffer;
-        copy->regions = {VkBufferImageCopy{0, 0, 0, VkImageSubresourceLayers{VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1}, VkOffset3D{0,0,0}, info.imageView->image->extent}};
+        copy->regions = {VkBufferImageCopy{materialStaging.offset, 0, 0, VkImageSubresourceLayers{VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1}, VkOffset3D{0,0,0}, info.imageView->image->extent}};
         commands->addChild(copy);
         // transfer image layout back
         memBarrier = vsg::ImageMemoryBarrier::create(VK_ACCESS_NONE_KHR, VK_ACCESS_SHADER_WRITE_BIT,VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, 

--- a/RenderIO.cpp
+++ b/RenderIO.cpp
@@ -176,7 +176,7 @@ bool GBufferIO::exportGBufferDepth(const std::string& depthFormat, const std::st
         //normal images
         snprintf(buff, sizeof(buff), normalFormat.c_str(), f);
         filename = buff;
-        if(!vsg::write(gBuffers[f]->normal, filename, options)){
+        if(!vsg::write(sphericalToCartesian(gBuffers[f]->normal.cast<vsg::vec2Array2D>()), filename, options)){
             std::cerr << "Failed to store image: " << filename << std::endl;
             fine = false;
             return;
@@ -184,7 +184,7 @@ bool GBufferIO::exportGBufferDepth(const std::string& depthFormat, const std::st
         //material images
         snprintf(buff, sizeof(buff), materialFormat.c_str(), f);
         filename = buff;
-        if(!vsg::write(gBuffers[f]->material, filename, options)){
+        if(!vsg::write(unormToFloat(gBuffers[f]->material.cast<vsg::ubvec4Array2D>()), filename, options)){
             std::cerr << "Failed to store image: " << filename << std::endl;
             fine = false;
             return;
@@ -192,7 +192,7 @@ bool GBufferIO::exportGBufferDepth(const std::string& depthFormat, const std::st
         //albedo images
         snprintf(buff, sizeof(buff), albedoFormat.c_str(), f);
         filename = buff;
-        if(!vsg::write(gBuffers[f]->albedo, filename, options)){
+        if(!vsg::write(unormToFloat(gBuffers[f]->albedo.cast<vsg::ubvec4Array2D>()), filename, options)){
             std::cerr << "Failed to store image: " << filename << std::endl;
             fine = false;
             return;
@@ -232,7 +232,7 @@ bool GBufferIO::exportGBufferPosition(const std::string& positionFormat, const s
         //normal images
         snprintf(buff, sizeof(buff), normalFormat.c_str(), f);
         filename = buff;
-        if(!vsg::write(gBuffers[f]->normal, filename, options)){
+        if(!vsg::write(sphericalToCartesian(gBuffers[f]->normal.cast<vsg::vec2Array2D>()), filename, options)){
             std::cerr << "Failed to store image: " << filename << std::endl;
             fine = false;
             return;
@@ -240,7 +240,7 @@ bool GBufferIO::exportGBufferPosition(const std::string& positionFormat, const s
         //material images
         snprintf(buff, sizeof(buff), materialFormat.c_str(), f);
         filename = buff;
-        if(!vsg::write(gBuffers[f]->material, filename, options)){
+        if(!vsg::write(unormToFloat(gBuffers[f]->material.cast<vsg::ubvec4Array2D>()), filename, options)){
             std::cerr << "Failed to store image: " << filename << std::endl;
             fine = false;
             return;
@@ -248,7 +248,7 @@ bool GBufferIO::exportGBufferPosition(const std::string& positionFormat, const s
         //albedo images
         snprintf(buff, sizeof(buff), albedoFormat.c_str(), f);
         filename = buff;
-        if(!vsg::write(gBuffers[f]->albedo, filename, options)){
+        if(!vsg::write(unormToFloat(gBuffers[f]->albedo.cast<vsg::ubvec4Array2D>()), filename, options)){
             std::cerr << "Failed to store image: " << filename << std::endl;
             fine = false;
             return;
@@ -277,6 +277,16 @@ vsg::ref_ptr<vsg::Data> GBufferIO::sphericalToCartesian(vsg::ref_ptr<vsg::vec2Ar
         res[i].w = 1;
     }
     return vsg::vec4Array2D::create(normals->width(), normals->height(), res, vsg::Data::Layout{VK_FORMAT_R32G32B32A32_SFLOAT});
+}
+
+vsg::ref_ptr<vsg::Data> GBufferIO::unormToFloat(vsg::ref_ptr<vsg::ubvec4Array2D> array){
+    if(!array) return {};
+    vsg::vec4* res = new vsg::vec4[array->valueCount()];
+    for(uint32_t i = 0; i < array->valueCount(); ++i){
+        vsg::ubvec4 col = array->data()[i];
+        res[i] = {static_cast<float>(col.x) / 255.f, static_cast<float>(col.y) / 255.f, static_cast<float>(col.z) / 255.f, static_cast<float>(col.w) / 255.f};
+    }
+    return vsg::vec4Array2D::create(array->width(), array->height(), res, vsg::Data::Layout{VK_FORMAT_R32G32B32A32_SFLOAT});
 }
 
 vsg::ref_ptr<vsg::Data> GBufferIO::depthToPosition(vsg::ref_ptr<vsg::floatArray2D> depths, const DoubleMatrix& matrix)
@@ -320,13 +330,32 @@ void OfflineIllumination::downloadFromIlluminationBufferCommand(vsg::ref_ptr<Ill
         setupStagingBuffer(illuBuffer->width, illuBuffer->height);
     if(illuBuffer->illuminationImages[0])
     {
+        //transfer image layout for optimal transfer and memory barrier
+        VkImageSubresourceRange resourceRange{VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+        auto memBarrier = vsg::ImageMemoryBarrier::create(VK_ACCESS_NONE_KHR, VK_ACCESS_TRANSFER_READ_BIT, VK_IMAGE_LAYOUT_GENERAL,
+                                                       VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, 0, 0, illuBuffer->illuminationImages[0]->imageInfoList.front().imageView->image,
+                                                       resourceRange);
+        auto pipelineBarrier = vsg::PipelineBarrier::create(VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR,
+                                                        VK_PIPELINE_STAGE_TRANSFER_BIT, VK_DEPENDENCY_BY_REGION_BIT,
+                                                        memBarrier);
+        commands->addChild(pipelineBarrier);
+        // copy image to buffer
         auto copy = vsg::CopyImageToBuffer::create();
         vsg::ImageInfo info = illuBuffer->illuminationImages[0]->imageInfoList.front();
         copy->srcImage = info.imageView->image;
-        copy->srcImageLayout = info.imageLayout;
+        copy->srcImageLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
         copy->dstBuffer = noisyStaging.buffer;
         copy->regions = {VkBufferImageCopy{0, 0, 0, VkImageSubresourceLayers{VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1}, VkOffset3D{0,0,0}, info.imageView->image->extent}};
         commands->addChild(copy);
+        // transfer image layout back
+        memBarrier = vsg::ImageMemoryBarrier::create(VK_ACCESS_NONE_KHR, VK_ACCESS_SHADER_WRITE_BIT,VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, 
+                                                    VK_IMAGE_LAYOUT_GENERAL, 0, 0, illuBuffer->illuminationImages[0]->imageInfoList.front().imageView->image,
+                                                    resourceRange);
+        pipelineBarrier = vsg::PipelineBarrier::create(VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR,
+                                                    VK_DEPENDENCY_BY_REGION_BIT,
+                                                    memBarrier);
+        commands->addChild(pipelineBarrier);
+
         illuBuffer->illuminationImages[0]->imageInfoList[0].imageView->image->usage |= VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
         noisyStaging.buffer->usage |= VK_BUFFER_USAGE_TRANSFER_DST_BIT;
     }
@@ -346,8 +375,8 @@ void OfflineIllumination::transferStagingDataTo(vsg::ref_ptr<OfflineIllumination
         return;
     }
     void* gpu_data;
-    memory->map(buffer->getMemoryOffset(deviceID) + noisyStaging.offset, buffer->size, 0, &gpu_data);
-    std::memcpy(illuBuffer->noisy->dataPointer(), gpu_data, (size_t)buffer->size);
+    memory->map(buffer->getMemoryOffset(deviceID) + noisyStaging.offset, noisyStaging.range, 0, &gpu_data);
+    std::memcpy(illuBuffer->noisy->dataPointer(), gpu_data, (size_t)noisyStaging.range);
     memory->unmap();
 }
 
@@ -510,46 +539,111 @@ void OfflineGBuffer::downloadFromGBufferCommand(vsg::ref_ptr<GBuffer>& gBuffer, 
         setupStagingBuffer(gBuffer->width, gBuffer->height);
     if(gBuffer->depth)
     {
+        //transfer image layout for optimal transfer and memory barrier
+        VkImageSubresourceRange resourceRange{VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+        auto memBarrier = vsg::ImageMemoryBarrier::create(VK_ACCESS_NONE_KHR, VK_ACCESS_TRANSFER_READ_BIT, VK_IMAGE_LAYOUT_GENERAL,
+                                                       VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, 0, 0, gBuffer->depth->imageInfoList.front().imageView->image,
+                                                       resourceRange);
+        auto pipelineBarrier = vsg::PipelineBarrier::create(VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR,
+                                                        VK_PIPELINE_STAGE_TRANSFER_BIT, VK_DEPENDENCY_BY_REGION_BIT,
+                                                        memBarrier);
+        commands->addChild(pipelineBarrier);
         auto copy = vsg::CopyImageToBuffer::create();
         vsg::ImageInfo info = gBuffer->depth->imageInfoList.front();
         copy->srcImage = info.imageView->image;
-        copy->srcImageLayout = info.imageLayout;
+        copy->srcImageLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
         copy->dstBuffer = depthStaging.buffer;
-        copy->regions = {VkBufferImageCopy{0, static_cast<uint32_t>(depthStaging.buffer->size), 1, VkImageSubresourceLayers{VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1}, VkOffset3D{0,0,0}, info.imageView->image->extent}};
+        copy->regions = {VkBufferImageCopy{0,0, 0, VkImageSubresourceLayers{VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1}, VkOffset3D{0,0,0}, info.imageView->image->extent}};
         commands->addChild(copy);
+        // transfer image layout back
+        memBarrier = vsg::ImageMemoryBarrier::create(VK_ACCESS_NONE_KHR, VK_ACCESS_SHADER_WRITE_BIT,VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, 
+                                                    VK_IMAGE_LAYOUT_GENERAL, 0, 0, gBuffer->depth->imageInfoList.front().imageView->image,
+                                                    resourceRange);
+        pipelineBarrier = vsg::PipelineBarrier::create(VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR,
+                                                    VK_DEPENDENCY_BY_REGION_BIT,
+                                                    memBarrier);
+        commands->addChild(pipelineBarrier);
         gBuffer->depth->imageInfoList[0].imageView->image->usage |= VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
     }
     if(gBuffer->normal)
     {
+        VkImageSubresourceRange resourceRange{VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+        auto memBarrier = vsg::ImageMemoryBarrier::create(VK_ACCESS_NONE_KHR, VK_ACCESS_TRANSFER_READ_BIT, VK_IMAGE_LAYOUT_GENERAL,
+                                                       VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, 0, 0, gBuffer->normal->imageInfoList.front().imageView->image,
+                                                       resourceRange);
+        auto pipelineBarrier = vsg::PipelineBarrier::create(VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR,
+                                                        VK_PIPELINE_STAGE_TRANSFER_BIT, VK_DEPENDENCY_BY_REGION_BIT,
+                                                        memBarrier);
+        commands->addChild(pipelineBarrier);
         auto copy = vsg::CopyImageToBuffer::create();
         vsg::ImageInfo info = gBuffer->normal->imageInfoList.front();
         copy->srcImage = info.imageView->image;
-        copy->srcImageLayout = info.imageLayout;
+        copy->srcImageLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
         copy->dstBuffer = normalStaging.buffer;
-        copy->regions = {VkBufferImageCopy{0, static_cast<uint32_t>(normalStaging.buffer->size), 1, VkImageSubresourceLayers{VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1}, VkOffset3D{0,0,0}, info.imageView->image->extent}};
+        copy->regions = {VkBufferImageCopy{0, 0, 0, VkImageSubresourceLayers{VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1}, VkOffset3D{0,0,0}, info.imageView->image->extent}};
         commands->addChild(copy);
+        // transfer image layout back
+        memBarrier = vsg::ImageMemoryBarrier::create(VK_ACCESS_NONE_KHR, VK_ACCESS_SHADER_WRITE_BIT,VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, 
+                                                    VK_IMAGE_LAYOUT_GENERAL, 0, 0, gBuffer->normal->imageInfoList.front().imageView->image,
+                                                    resourceRange);
+        pipelineBarrier = vsg::PipelineBarrier::create(VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR,
+                                                    VK_DEPENDENCY_BY_REGION_BIT,
+                                                    memBarrier);
+        commands->addChild(pipelineBarrier);
         gBuffer->normal->imageInfoList[0].imageView->image->usage |= VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
     }
     if(gBuffer->albedo)
     {
+        VkImageSubresourceRange resourceRange{VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+        auto memBarrier = vsg::ImageMemoryBarrier::create(VK_ACCESS_NONE_KHR, VK_ACCESS_TRANSFER_READ_BIT, VK_IMAGE_LAYOUT_GENERAL,
+                                                       VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, 0, 0, gBuffer->albedo->imageInfoList.front().imageView->image,
+                                                       resourceRange);
+        auto pipelineBarrier = vsg::PipelineBarrier::create(VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR,
+                                                        VK_PIPELINE_STAGE_TRANSFER_BIT, VK_DEPENDENCY_BY_REGION_BIT,
+                                                        memBarrier);
+        commands->addChild(pipelineBarrier);
         auto copy = vsg::CopyImageToBuffer::create();
         vsg::ImageInfo info = gBuffer->albedo->imageInfoList.front();
         copy->srcImage = info.imageView->image;
-        copy->srcImageLayout = info.imageLayout;
+        copy->srcImageLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
         copy->dstBuffer = albedoStaging.buffer;
-        copy->regions = {VkBufferImageCopy{0, static_cast<uint32_t>(normalStaging.buffer->size), 1, VkImageSubresourceLayers{VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1}, VkOffset3D{0,0,0}, info.imageView->image->extent}};
+        copy->regions = {VkBufferImageCopy{0, 0, 0, VkImageSubresourceLayers{VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1}, VkOffset3D{0,0,0}, info.imageView->image->extent}};
         commands->addChild(copy);
+        // transfer image layout back
+        memBarrier = vsg::ImageMemoryBarrier::create(VK_ACCESS_NONE_KHR, VK_ACCESS_SHADER_WRITE_BIT,VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, 
+                                                    VK_IMAGE_LAYOUT_GENERAL, 0, 0, gBuffer->albedo->imageInfoList.front().imageView->image,
+                                                    resourceRange);
+        pipelineBarrier = vsg::PipelineBarrier::create(VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR,
+                                                    VK_DEPENDENCY_BY_REGION_BIT,
+                                                    memBarrier);
+        commands->addChild(pipelineBarrier);
         gBuffer->albedo->imageInfoList[0].imageView->image->usage |= VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
     }
     if(gBuffer->material)
     {
+        VkImageSubresourceRange resourceRange{VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+        auto memBarrier = vsg::ImageMemoryBarrier::create(VK_ACCESS_NONE_KHR, VK_ACCESS_TRANSFER_READ_BIT, VK_IMAGE_LAYOUT_GENERAL,
+                                                       VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, 0, 0, gBuffer->material->imageInfoList.front().imageView->image,
+                                                       resourceRange);
+        auto pipelineBarrier = vsg::PipelineBarrier::create(VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR,
+                                                        VK_PIPELINE_STAGE_TRANSFER_BIT, VK_DEPENDENCY_BY_REGION_BIT,
+                                                        memBarrier);
+        commands->addChild(pipelineBarrier);
         auto copy = vsg::CopyImageToBuffer::create();
         vsg::ImageInfo info = gBuffer->material->imageInfoList.front();
         copy->srcImage = info.imageView->image;
-        copy->srcImageLayout = info.imageLayout;
+        copy->srcImageLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
         copy->dstBuffer = materialStaging.buffer;
-        copy->regions = {VkBufferImageCopy{0, static_cast<uint32_t>(normalStaging.buffer->size), 1, VkImageSubresourceLayers{VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1}, VkOffset3D{0,0,0}, info.imageView->image->extent}};
+        copy->regions = {VkBufferImageCopy{0, 0, 0, VkImageSubresourceLayers{VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1}, VkOffset3D{0,0,0}, info.imageView->image->extent}};
         commands->addChild(copy);
+        // transfer image layout back
+        memBarrier = vsg::ImageMemoryBarrier::create(VK_ACCESS_NONE_KHR, VK_ACCESS_SHADER_WRITE_BIT,VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, 
+                                                    VK_IMAGE_LAYOUT_GENERAL, 0, 0, gBuffer->material->imageInfoList.front().imageView->image,
+                                                    resourceRange);
+        pipelineBarrier = vsg::PipelineBarrier::create(VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR,
+                                                    VK_DEPENDENCY_BY_REGION_BIT,
+                                                    memBarrier);
+        commands->addChild(pipelineBarrier);
         gBuffer->material->imageInfoList[0].imageView->image->usage |= VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
     }
 }
@@ -568,8 +662,8 @@ void OfflineGBuffer::transferStagingDataTo(vsg::ref_ptr<OfflineGBuffer> other)
         return;
     }
     void* gpu_data;
-    memory->map(buffer->getMemoryOffset(deviceID) + depthStaging.offset, buffer->size, 0, &gpu_data);
-    std::memcpy(other->depth->dataPointer(), gpu_data, (size_t)buffer->size);
+    memory->map(buffer->getMemoryOffset(deviceID) + depthStaging.offset, depthStaging.range, 0, &gpu_data);
+    std::memcpy(other->depth->dataPointer(), gpu_data, (size_t)depthStaging.range);
     memory->unmap();
 
     buffer = vsg::ref_ptr<vsg::Buffer>(normalStaging.buffer);
@@ -578,8 +672,8 @@ void OfflineGBuffer::transferStagingDataTo(vsg::ref_ptr<OfflineGBuffer> other)
         std::cout << "Error while transferring normal staging memory data to offline gBuffer." << std::endl;
         return;
     }
-    memory->map(buffer->getMemoryOffset(deviceID) + normalStaging.offset, buffer->size, 0, &gpu_data);
-    std::memcpy(other->normal->dataPointer(), gpu_data, (size_t)buffer->size);
+    memory->map(buffer->getMemoryOffset(deviceID) + normalStaging.offset, normalStaging.range, 0, &gpu_data);
+    std::memcpy(other->normal->dataPointer(), gpu_data, (size_t)normalStaging.range);
     memory->unmap();
 
     buffer = vsg::ref_ptr<vsg::Buffer>(albedoStaging.buffer);
@@ -588,8 +682,8 @@ void OfflineGBuffer::transferStagingDataTo(vsg::ref_ptr<OfflineGBuffer> other)
         std::cout << "Error while transferring albedo staging memory data to offline gBuffer." << std::endl;
         return;
     }
-    memory->map(buffer->getMemoryOffset(deviceID) + albedoStaging.offset, buffer->size, 0, &gpu_data);
-    std::memcpy(other->albedo->dataPointer(), gpu_data, (size_t)buffer->size);
+    memory->map(buffer->getMemoryOffset(deviceID) + albedoStaging.offset, albedoStaging.range, 0, &gpu_data);
+    std::memcpy(other->albedo->dataPointer(), gpu_data, (size_t)albedoStaging.range);
     memory->unmap();
 
     buffer = vsg::ref_ptr<vsg::Buffer>(materialStaging.buffer);
@@ -598,8 +692,8 @@ void OfflineGBuffer::transferStagingDataTo(vsg::ref_ptr<OfflineGBuffer> other)
         std::cout << "Error while transferring material staging memory data to offline gBuffer." << std::endl;
         return;
     }
-    memory->map(buffer->getMemoryOffset(deviceID) + materialStaging.offset, buffer->size, 0, &gpu_data);
-    std::memcpy(other->material->dataPointer(), gpu_data, (size_t)buffer->size);
+    memory->map(buffer->getMemoryOffset(deviceID) + materialStaging.offset, materialStaging.range, 0, &gpu_data);
+    std::memcpy(other->material->dataPointer(), gpu_data, (size_t)materialStaging.range);
     memory->unmap();
 }
 

--- a/RenderIO.cpp
+++ b/RenderIO.cpp
@@ -325,7 +325,7 @@ void OfflineIllumination::downloadFromIlluminationBufferCommand(vsg::ref_ptr<Ill
         copy->srcImage = info.imageView->image;
         copy->srcImageLayout = info.imageLayout;
         copy->dstBuffer = noisyStaging.buffer;
-        copy->regions = {VkBufferImageCopy{0, static_cast<uint32_t>(noisyStaging.buffer->size), 1, VkImageSubresourceLayers{VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1}, VkOffset3D{0,0,0}, info.imageView->image->extent}};
+        copy->regions = {VkBufferImageCopy{0, 0, 0, VkImageSubresourceLayers{VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1}, VkOffset3D{0,0,0}, info.imageView->image->extent}};
         commands->addChild(copy);
         illuBuffer->illuminationImages[0]->imageInfoList[0].imageView->image->usage |= VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
         noisyStaging.buffer->usage |= VK_BUFFER_USAGE_TRANSFER_DST_BIT;
@@ -419,6 +419,7 @@ bool IlluminationBufferIO::exportIllumination(const std::string& illuminationFor
         char buff[200];
         std::string filename;
         snprintf(buff, sizeof(buff), illuminationFormat.c_str(), f);
+        filename = buff;
         if(!vsg::write(illus[f]->noisy, filename, options)){
             std::cout << "Faled to store image: " << filename << std::endl;
             fine = false;

--- a/RenderIO.hpp
+++ b/RenderIO.hpp
@@ -58,6 +58,7 @@ private:
     static vsg::ref_ptr<vsg::Data> convertNormalToSpherical(vsg::ref_ptr<vsg::vec4Array2D> normals);
     static vsg::ref_ptr<vsg::Data> compressAlbedo(vsg::ref_ptr<vsg::Data> in);
     static vsg::ref_ptr<vsg::Data> sphericalToCartesian(vsg::ref_ptr<vsg::vec2Array2D> normals);
+    static vsg::ref_ptr<vsg::Data> unormToFloat(vsg::ref_ptr<vsg::ubvec4Array2D> array);
     static vsg::ref_ptr<vsg::Data> depthToPosition(vsg::ref_ptr<vsg::floatArray2D> depths, const DoubleMatrix& matrix);
 };
 

--- a/RenderIO.hpp
+++ b/RenderIO.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <optional>
 #include <vsg/all.h>
 #include <vsgXchange/images.h>
 #include <vector>

--- a/RenderIO.hpp
+++ b/RenderIO.hpp
@@ -21,7 +21,8 @@ public:
 // Matrices ------------------------------------------------------------------------
 class DoubleMatrix{
 public:
-    vsg::mat4 view, invView;
+    vsg::mat4 view, invView;    //if no projection matrix is available, the projection and view matricesa are combined in the view matrix
+    std::optional<vsg::mat4> proj, invProj;
 };
 using DoubleMatrices = std::vector<DoubleMatrix>;
 
@@ -52,8 +53,7 @@ class GBufferIO{
 public:
     static OfflineGBuffers importGBufferDepth(const std::string& depthFormat, const std::string& normalFormat, const std::string& materialFormat, const std::string& albedoFormat, int numFrames, int verbosity = 1);
     static OfflineGBuffers importGBufferPosition(const std::string& positionFormat, const std::string& normalFormat, const std::string& materialFormat, const std::string& albedoFormat, const std::vector<DoubleMatrix>& matrices, int numFrames, int verbosity = 1);
-    static bool exportGBufferDepth(const std::string& depthFormat, const std::string& normalFormat, const std::string& materialFormat, const std::string& albedoFormat, int numFrames, const OfflineGBuffers& gBuffers, int verbosity = 1);
-    static bool exportGBufferPosition(const std::string& positionFormat, const std::string& normalFormat, const std::string& materialFormat, const std::string& albedoFormat, int numFrames, const OfflineGBuffers& gBuffers, const DoubleMatrices& matrices, int verbosity = 1);
+    static bool exportGBuffer(const std::string& positionFormat, const std::string& depthFormat, const std::string& normalFormat, const std::string& materialFormat, const std::string& albedoFormat, int numFrames, const OfflineGBuffers& gBuffers, const DoubleMatrices& matrices, int verbosity = 1);
 private:
     static vsg::ref_ptr<vsg::Data> convertNormalToSpherical(vsg::ref_ptr<vsg::vec4Array2D> normals);
     static vsg::ref_ptr<vsg::Data> compressAlbedo(vsg::ref_ptr<vsg::Data> in);

--- a/VulkanPBRT.cpp
+++ b/VulkanPBRT.cpp
@@ -120,8 +120,6 @@ int main(int argc, char** argv){
         }
         bool useTaa = arguments.read("--taa");
         bool useFlyNavigation = arguments.read("--fly");
-        bool highQualityIllumiation = arguments.read({"--highqual" ,"-hq"}) || exportIllumination;  //exporting illumination automatically requires hq illumination buffer
-
 #ifdef _DEBUG
         // overwriting command line options for debug
         windowTraits->debugLayer = true;
@@ -303,9 +301,6 @@ int main(int argc, char** argv){
         else
         {
             writeGBuffer = false;
-            illuminationBuffer = IlluminationBufferFinal::create(windowTraits->width, windowTraits->height);
-        }
-        if (highQualityIllumiation){
             illuminationBuffer = IlluminatonBufferFinalFloat::create(windowTraits->width, windowTraits->height);
         }
         if (exportIllumination && !gBuffer){

--- a/VulkanPBRT.cpp
+++ b/VulkanPBRT.cpp
@@ -85,15 +85,24 @@ int main(int argc, char** argv){
         arguments.read("--screen", windowTraits->screenNum);	
 
         auto numFrames = arguments.value(-1, "-f");
-        auto depthImages = arguments.value(std::string(), "--depths");
-        auto positionImages = arguments.value(std::string(), "--positions");
-        auto normalImages = arguments.value(std::string(), "--normals");
-        auto albedoImages = arguments.value(std::string(), "--albedos");
-        auto materialImages = arguments.value(std::string(), "--materials");
-        auto illuminationImages = arguments.value(std::string(), "--illuminations");
+        auto depthPath = arguments.value(std::string(), "--depths");
+        auto exportDepthPath = arguments.value(std::string(), "--exportDepth");
+        auto positionPath = arguments.value(std::string(), "--positions");
+        auto exportPositionPath = arguments.value(std::string(), "--exportPosition");
+        auto normalPath = arguments.value(std::string(), "--normals");
+        auto exportNormalPath = arguments.value(std::string(), "--exportNormal");
+        auto albedoPath = arguments.value(std::string(), "--albedos");
+        auto exportAlbedoPath = arguments.value(std::string(), "--exportAlbedo");
+        auto materialPath = arguments.value(std::string(), "--materials");
+        auto exportMaterialPath = arguments.value(std::string(), "--exportMaterial");
+        auto illuminationPath = arguments.value(std::string(), "--illuminations");
+        auto exportIlluminationPath = arguments.value(std::string(), "--exportIllumination");
         auto matricesPath = arguments.value(std::string(), "--matrices");
+        auto exportMatricesPath = arguments.value(std::string(), "--exportMatrices");
         auto sceneFilename = arguments.value(std::string(), "-i");
-        bool externalRenderings = normalImages.size();
+        bool externalRenderings = normalPath.size();
+        bool exportIllumination = exportIlluminationPath.size();
+        bool exportGBuffer = exportNormalPath.size();
         if (sceneFilename.empty() && !externalRenderings)
         {
             std::cout << "Missing input parameter \"-i <path_to_model>\"." << std::endl;
@@ -111,6 +120,7 @@ int main(int argc, char** argv){
         }
         bool useTaa = arguments.read("--taa");
         bool useFlyNavigation = arguments.read("--fly");
+        bool highQualityIllumiation = arguments.read({"--highqual" ,"-hq"}) || exportIllumination;  //exporting illumination automatically requires hq illumination buffer
 
 #ifdef _DEBUG
         // overwriting command line options for debug
@@ -161,15 +171,33 @@ int main(int argc, char** argv){
                 std::cout << "Camera matrices could not be loaded" << std::endl;
                 return 1;
             }
-            if(positionImages.size()){
-                offlineGBuffers = GBufferIO::importGBufferPosition(positionImages, normalImages, materialImages, albedoImages, cameraMatrices, numFrames);
+            if(positionPath.size()){
+                offlineGBuffers = GBufferIO::importGBufferPosition(positionPath, normalPath, materialPath, albedoPath, cameraMatrices, numFrames);
             }
             else{
-                offlineGBuffers = GBufferIO::importGBufferDepth(depthImages, normalImages, materialImages, albedoImages, numFrames);
+                offlineGBuffers = GBufferIO::importGBufferDepth(depthPath, normalPath, materialPath, albedoPath, numFrames);
             }
-            offlineIlluminations = IlluminationBufferIO::importIllumination(illuminationImages, numFrames);
+            offlineIlluminations = IlluminationBufferIO::importIllumination(illuminationPath, numFrames);
             windowTraits->width = offlineGBuffers[0]->depth->width();
             windowTraits->height = offlineGBuffers[0]->depth->height();
+        }
+        if(exportIllumination){
+            if(numFrames <= 0){
+                std::cout << "No number of frames given. For usage of Illumination export use \"-f\" to inform about the number of frames." << std::endl;
+                return 1;
+            }
+            if(offlineIlluminations.empty()){
+                offlineIlluminations.resize(numFrames);
+            }
+        }
+        if(exportGBuffer){
+            if(numFrames <= 0){
+                std::cout << "No number of frames given. For usage of GBuffer export use \"-f\" to inform about the number of frames." << std::endl;
+                return 1;
+            }
+            if(offlineGBuffers.empty()){
+                offlineGBuffers.resize(numFrames);
+            }
         }
 
         auto window = vsg::Window::create(windowTraits);
@@ -265,6 +293,9 @@ int main(int argc, char** argv){
         {
             writeGBuffer = false;
             illuminationBuffer = IlluminationBufferFinal::create(windowTraits->width, windowTraits->height);
+        }
+        if  (highQualityIllumiation){
+            illuminationBuffer = IlluminatonBufferFinalFloat::create(windowTraits->width, windowTraits->height);
         }
         if (useTaa && !accumulationBuffer)
         {
@@ -447,6 +478,16 @@ int main(int argc, char** argv){
             taa->addDispatchToCommandGraph(commands);
             finalDescriptorImage = taa->getFinalDescriptorImage();
         }
+        if(exportGBuffer){
+            offlineGBufferStager->downloadFromGBufferCommand(gBuffer, commands, imageLayoutCompile.context);
+        }
+        if(exportIllumination){
+            if(finalDescriptorImage->imageInfoList[0].imageView->image->format != VK_FORMAT_R32G32B32A32_SFLOAT){
+                std::cout << "Final image layout is not compatible illumination buffer export" << std::endl;
+                return 1;
+            }
+            offlineIlluminationBufferStager->downloadFromIlluminationBufferCommand(illuminationBuffer, commands, imageLayoutCompile.context);
+        }
         if(finalDescriptorImage->imageInfoList[0].imageView->image->format != VK_FORMAT_B8G8R8A8_UNORM){
             auto converter = FormatConverter::create(finalDescriptorImage->imageInfoList[0].imageView, VK_FORMAT_B8G8R8A8_UNORM);
             converter->compileImages(imageLayoutCompile.context);
@@ -506,7 +547,7 @@ int main(int argc, char** argv){
         viewer->assignRecordAndSubmitTaskAndPresentation({commandGraph});
         viewer->compile();
 
-        //waiting for image layout transitions
+        // waiting for image layout transitions
         imageLayoutCompile.context.waitForCompletion();
 
         while(viewer->advanceToNextFrame() && (numFrames < 0 || (numFrames--) > 0)){
@@ -534,6 +575,18 @@ int main(int argc, char** argv){
             viewer->present();
 
             lookAt->get(rayTracingPushConstantsValue->value().prevView);
+        }
+
+        // exporting all images
+        if(exportGBuffer){
+            if(exportDepthPath.size())
+                GBufferIO::exportGBufferDepth(exportDepthPath, exportNormalPath, exportMaterialPath, exportAlbedoPath, numFrames, offlineGBuffers);
+            if(exportPositionPath.size()){
+                GBufferIO::exportGBufferPosition(exportPositionPath, exportNormalPath, exportMaterialPath, exportAlbedoPath, numFrames, offlineGBuffers, cameraMatrices);
+            }
+        }
+        if(exportIllumination){
+            IlluminationBufferIO::exportIllumination(exportIlluminationPath, numFrames, offlineIlluminations);
         }
     }
     catch (const vsg::Exception& e){

--- a/VulkanPBRT.cpp
+++ b/VulkanPBRT.cpp
@@ -201,6 +201,13 @@ int main(int argc, char** argv){
             }
             if(offlineGBuffers.empty()){
                 offlineGBuffers.resize(numFrames);
+                for(auto& i: offlineGBuffers){
+                    i = OfflineGBuffer::create();
+                    i->depth = vsg::floatArray2D::create(windowTraits->width, windowTraits->height);
+                    i->normal = vsg::vec2Array2D::create(windowTraits->width, windowTraits->height);
+                    i->albedo = vsg::ubvec4Array2D::create(windowTraits->width, windowTraits->height);
+                    i->material = vsg::ubvec4Array2D::create(windowTraits->width, windowTraits->height);
+                }
             }
         }
 
@@ -298,8 +305,12 @@ int main(int argc, char** argv){
             writeGBuffer = false;
             illuminationBuffer = IlluminationBufferFinal::create(windowTraits->width, windowTraits->height);
         }
-        if  (highQualityIllumiation){
+        if (highQualityIllumiation){
             illuminationBuffer = IlluminatonBufferFinalFloat::create(windowTraits->width, windowTraits->height);
+        }
+        if (exportIllumination && !gBuffer){
+            writeGBuffer = true;
+            gBuffer = GBuffer::create(windowTraits->width, windowTraits->height);
         }
         if (useTaa && !accumulationBuffer)
         {
@@ -588,6 +599,10 @@ int main(int argc, char** argv){
             if(exportIllumination){
                 int frame = offlineIlluminations.size() - 1 - numFrames;
                 offlineIlluminationBufferStager->transferStagingDataTo(offlineIlluminations[frame]);
+            }
+            if(exportGBuffer){
+                int frame = offlineIlluminations.size() - 1 - numFrames;
+                offlineGBufferStager->transferStagingDataTo(offlineGBuffers[frame]);
             }
         }
         numFrames = numFramesC;

--- a/VulkanPBRT.cpp
+++ b/VulkanPBRT.cpp
@@ -596,6 +596,9 @@ int main(int argc, char** argv){
 
             lookAt->get(rayTracingPushConstantsValue->value().prevView);
 
+            if(exportGBuffer || exportIllumination){
+                viewer->deviceWaitIdle();
+            }
             if(exportIllumination){
                 int frame = offlineIlluminations.size() - 1 - numFrames;
                 offlineIlluminationBufferStager->transferStagingDataTo(offlineIlluminations[frame]);

--- a/shaders/layoutPTImages.glsl
+++ b/shaders/layoutPTImages.glsl
@@ -5,6 +5,11 @@
 layout(binding = 1, set = 0, rgba8) uniform image2D outputImage;
 #endif
 
+#ifdef FINAL_IMAGE_HQ
+layout(binding = 1, set = 0, rgba32f) uniform image2D outputImage;
+#define FINAL_IMAGE
+#endif
+
 #ifdef GBUFFER
 layout(binding = 15, r32f) uniform image2D depthImage;
 layout(binding = 16, rg32f) uniform image2D normalImage;

--- a/shaders/layoutPTImages.glsl
+++ b/shaders/layoutPTImages.glsl
@@ -2,12 +2,7 @@
 #define LAYOUTPTIMAGES_H
 
 #ifdef FINAL_IMAGE
-layout(binding = 1, rgba8) uniform image2D outputImage;
-#endif
-
-#ifdef FINAL_IMAGE_HQ
 layout(binding = 1, rgba32f) uniform image2D outputImage;
-#define FINAL_IMAGE
 #endif
 
 #ifdef GBUFFER

--- a/shaders/layoutPTImages.glsl
+++ b/shaders/layoutPTImages.glsl
@@ -2,11 +2,11 @@
 #define LAYOUTPTIMAGES_H
 
 #ifdef FINAL_IMAGE
-layout(binding = 1, set = 0, rgba8) uniform image2D outputImage;
+layout(binding = 1, rgba8) uniform image2D outputImage;
 #endif
 
 #ifdef FINAL_IMAGE_HQ
-layout(binding = 1, set = 0, rgba32f) uniform image2D outputImage;
+layout(binding = 1, rgba32f) uniform image2D outputImage;
 #define FINAL_IMAGE
 #endif
 

--- a/shaders/ptMiss.rmiss
+++ b/shaders/ptMiss.rmiss
@@ -10,4 +10,6 @@ void main()
     rayPayload.position = vec3(1.0e10);
     rayPayload.si.normal = vec3(1);
     rayPayload.si.emissiveColor = vec3(0);
+    rayPayload.si.diffuseColor = vec3(0);
+    rayPayload.si.specularColor = vec3(0);
 }

--- a/shaders/ptRaygen.rgen
+++ b/shaders/ptRaygen.rgen
@@ -32,7 +32,8 @@ void main(){
     #ifdef FINAL_IMAGE
     #ifndef DEMOD_ILLUMINATION
     #ifndef DEMOD_ILLUMINATION_SQUARED
-    	antiAlias = true;	//can not be done when reprojecting
+	if(camParams.sampleNumber > 0)
+    	antiAlias = true;	//can not be done when reprojecting, never is done for first sample
     #endif
     #endif
     #endif

--- a/shaders/ptRaygen.rgen
+++ b/shaders/ptRaygen.rgen
@@ -2,7 +2,7 @@
 #extension GL_EXT_ray_tracing : enable
 #extension GL_GOOGLE_include_directive : enable
 
-#pragma import_defines (FINAL_IMAGE, GBUFFER, PREV_GBUFFER, DEMOD_ILLUMINATION, DEMOD_ILLUMINATION_SQUARED)
+#pragma import_defines (FINAL_IMAGE, FINAL_IMAGE_HQ, GBUFFER, PREV_GBUFFER, DEMOD_ILLUMINATION, DEMOD_ILLUMINATION_SQUARED)
 
 #include "ptStructures.glsl"
 #include "layoutPTAccel.glsl"

--- a/shaders/ptRaygen.rgen
+++ b/shaders/ptRaygen.rgen
@@ -53,7 +53,7 @@ void main(){
 	compressedNormal.x = acos(rayPayload.si.normal.z);
 	compressedNormal.y = atan(rayPayload.si.normal.y, rayPayload.si.normal.x);
 	imageStore(normalImage, ivec2(gl_LaunchIDEXT.xy), vec4(compressedNormal, 1, 1));
-	imageStore(materialImage, ivec2(gl_LaunchIDEXT.xy), vec4(rayPayload.reflector));
+	imageStore(materialImage, ivec2(gl_LaunchIDEXT.xy), vec4(1));
 	imageStore(albedoImage, ivec2(gl_LaunchIDEXT.xy), vec4(curAlbedo, 1));
 #endif
 

--- a/vsg/src/vsgXchange/openexr/openexr.cpp
+++ b/vsg/src/vsgXchange/openexr/openexr.cpp
@@ -541,7 +541,7 @@ bool openexr::getFeatures(Features& features) const
 {
     for (auto& ext : _supportedExtensions)
     {
-        features.extensionFeatureMap[ext] = static_cast<vsg::ReaderWriter::FeatureMask>(vsg::ReaderWriter::READ_FILENAME | vsg::ReaderWriter::READ_ISTREAM | vsg::ReaderWriter::READ_MEMORY);
+        features.extensionFeatureMap[ext] = static_cast<vsg::ReaderWriter::FeatureMask>(vsg::ReaderWriter::READ_FILENAME | vsg::ReaderWriter::READ_ISTREAM | vsg::ReaderWriter::READ_MEMORY | vsg::ReaderWriter::WRITE_FILENAME | vsg::ReaderWriter::WRITE_OSTREAM);
     }
     return true;
 }


### PR DESCRIPTION
Adds the ability to use external .exr images and denoises them as well as adds the ability to export renderings.
The following command line arguments have been added:
`--dephts` :  filename format of external depth images
`--exportDepth`: filename format of exported depth images
`--positions`: filename format of external positions (only depths or positions should be specified. If both, depth is taken)
`--exportPosition`: filename format of exported position images
`--normals`: filename format of external normal images
`--exportNormal`: filename format of exported normal images
`--albedos`: filename format of external albedo images
`--exportAlbedo`: filename format of exported albedo images
`--materials`: filename format of external material images (currently not used)
`--exportMaterial`: filename format of exported material images (are exported!)
`--matrices`: filename format of external camera matrices corresponding to external dataset (currently only dataset of BMFR matrices can be read)
`--exportMatrices`: filename format of exported camera matrices (currently not used, have not yet decided on file format to store matrices)
Format means that the filename can be a c-style format string with a single `%d` where the frame number will be inserted (eg: `"folder/depth_%d.exr"`).

Further an option for high quality path tracing has been added as the currently used rgba8 buffer (8 bit per channel) fails to get rid of all noise.
`-hq` or `--highqual` enables the 4 component float resulting image.

For review check compilation, your scenes and high quality mode (and maybe export).