### PR TITLE
Skylight and 3D-FRONT import fix

### DIFF
--- a/shaders/lighting.glsl
+++ b/shaders/lighting.glsl
@@ -109,10 +109,11 @@ vec3 nextEventEsitmation(vec3 pos, vec3 o, SurfaceInfo s, vec3 throughput, inout
   return min(throughput * light, vec3(c_MaxRadiance));
 }
 
-vec3 indirectLighting(vec3 pos, vec3 v, SurfaceInfo s, int recDepth, inout vec3 throughput, inout RandomEngine re){
+vec3 indirectLighting(vec3 pos, vec3 v, SurfaceInfo s, int recDepth, inout vec3 throughput, inout RandomEngine re, out vec3 sampled_direction){
   vec3 l;
   float pdf;
   vec3 brdf = sampleBRDF(s, re, v, l, pdf);
+  sampled_direction = l;
   if(brdf == vec3(0) || pdf < EPSILON){
     return vec3(0);
   }

--- a/shaders/ptRaygen.rgen
+++ b/shaders/ptRaygen.rgen
@@ -21,6 +21,15 @@ float tmax = 10000.0;
 #include "camera.glsl"
 #include "lighting.glsl"
 
+vec3 GetSkyColor(vec3 direction) 
+{
+	vec3 upper_color = SRGBtoLINEAR(vec3(0.3, 0.5, 0.92));
+	upper_color = mix(vec3(1), upper_color, max(direction.z, 0));
+	vec3 lower_color = vec3(0.2, 0.2, 0.2);
+	float weight = smoothstep(-0.02, 0.02, direction.z);
+	return mix(lower_color, upper_color, weight);
+}
+
 void main(){
     // --------------------------------------------------------------------
 	// random engine generation + ray generation (including first hit infos and first hit direct lighting)
@@ -42,6 +51,10 @@ void main(){
     vec3 finalColor = vec3(0);
     finalColor += nextEventEsitmation(rayPayload.position, -normalize(worldSpaceDir.xyz), rayPayload.si, throughput, re);
     finalColor += rayPayload.si.emissiveColor;
+	if (rayPayload.si.normal == vec3(1)) 
+	{
+		finalColor += GetSkyColor(worldSpaceDir.xyz);
+	}
     // --------------------------------------------------------------------
 	// storing GBuffer information
 	// --------------------------------------------------------------------
@@ -117,8 +130,13 @@ void main(){
 		for(int i = 0; i < infos.maxRecursionDepth; ++i){
 			vec3 v = normalize(worldSpacePos.xyz - rayPayload.position);
 			worldSpacePos = vec4(rayPayload.position, 1);
-			vec3 indir = indirectLighting(worldSpacePos.xyz, v, rayPayload.si, i, throughput, re);
-			if(rayPayload.si.normal == vec3(1)) break;	//stop recursion when sky was hit
+			vec3 sampled_direction;
+			vec3 indir = indirectLighting(worldSpacePos.xyz, v, rayPayload.si, i, throughput, re, sampled_direction);
+			if(rayPayload.si.normal == vec3(1)) 
+			{
+				finalColor += GetSkyColor(sampled_direction) * throughput;
+				break;	//stop recursion when sky was hit
+			}
 			finalColor += indir;
 		}
 	}


### PR DESCRIPTION
- fixed 3D-FRONT importer crashing when vertex data is given as string instead of float (e.g. in 0a8d471a-2587-458a-9214-586e003e9cf9.json)
- added simple gradient sky and sky lighting