### PR TITLE
Reprojection performance test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ set(SHADERS
     ptRaygen.rgen
     ptClosesthit.rchit
     ptMiss.rmiss
+    accumulator.comp
 )
 
 set(UNCOMPILED_SHADERS
@@ -58,7 +59,6 @@ set(UNCOMPILED_SHADERS
     camera.glsl
     color.glsl
     ptRaygen.rgen
-    accumulator.comp
     formatConverter.comp
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,6 @@ set(SHADERS
     ptRaygen.rgen
     ptClosesthit.rchit
     ptMiss.rmiss
-    accumulator.comp
 )
 
 set(UNCOMPILED_SHADERS
@@ -60,6 +59,7 @@ set(UNCOMPILED_SHADERS
     color.glsl
     ptRaygen.rgen
     formatConverter.comp
+    accumulator.comp
 )
 
 ## compilation of shader files

--- a/external/vsg/include/vsg/commands/WriteTimestamp.h
+++ b/external/vsg/include/vsg/commands/WriteTimestamp.h
@@ -8,7 +8,7 @@ namespace vsg
     class VSG_DECLSPEC WriteTimestamp : public Inherit<Command, WriteTimestamp>
     {
     public:
-        WriteTimestamp(ref_ptr<QueryPool> pool, uint32_t index, VkPipelineStageFlagBits stage): queryPool(pool), queryIndex(index), pipelineStage(stage) {}
+        WriteTimestamp(ref_ptr<QueryPool> pool, uint32_t index, VkPipelineStageFlagBits stage): queryPool(pool), queryIndex(index), pipelineStage(stage) {};
 
         ref_ptr<QueryPool> queryPool;
         uint32_t queryIndex;

--- a/external/vsg/include/vsg/state/QueryPool.h
+++ b/external/vsg/include/vsg/state/QueryPool.h
@@ -9,7 +9,7 @@ namespace vsg
     class VSG_DECLSPEC QueryPool : public Inherit<Object, QueryPool>
     {
     public:
-        QueryPool();
+        QueryPool(){};
 
         ~QueryPool();
 
@@ -21,15 +21,15 @@ namespace vsg
         void read(Input& input) override;
         void write(Output& output) const override;
 
-        void reset(Context& context);
-        std::vector<uint32_t> getResults(Context& context);
+        void reset();
+        std::vector<uint32_t> getResults();
 
         void compile(Context& context);
 
         operator VkQueryPool() const { return _queryPool; }
     protected:
-        VkQueryPool _queryPool;
-        ref_ptr<Device> _device;
+        VkQueryPool _queryPool{};
+        ref_ptr<Device> _device{};
     };
 
 } // namespace vsg

--- a/external/vsg/src/vsg/commands/WriteTimestamp.cpp
+++ b/external/vsg/src/vsg/commands/WriteTimestamp.cpp
@@ -2,6 +2,14 @@
 
 using namespace vsg;
 
+void WriteTimestamp::read(Input& input){
+
+}
+
+void WriteTimestamp::write(Output& output) const{
+    
+}
+
 void WriteTimestamp::compile(Context& context){
     queryPool->compile(context);
 }

--- a/external/vsg/src/vsg/state/QueryPool.cpp
+++ b/external/vsg/src/vsg/state/QueryPool.cpp
@@ -38,7 +38,7 @@ void QueryPool::reset(){
 
 std::vector<uint32_t> QueryPool::getResults(){
     std::vector<uint32_t> res(queryCount);
-    if (VkResult result = vkGetQueryPoolResults(*_device, _queryPool, 0, queryCount, queryCount * sizeof(uint32_t), res.data(), sizeof(uint32_t), 0); result != VK_SUCCESS){
+    if (VkResult result = vkGetQueryPoolResults(*_device, _queryPool, 0, queryCount, queryCount * sizeof(uint32_t), res.data(), sizeof(uint32_t), VK_QUERY_RESULT_WAIT_BIT); result != VK_SUCCESS){
         throw Exception{"Error: Failed to get QueryPool results.", result};
     }
     return res;

--- a/external/vsg/src/vsg/state/QueryPool.cpp
+++ b/external/vsg/src/vsg/state/QueryPool.cpp
@@ -31,14 +31,14 @@ void QueryPool::write(Output& output) const{
     output.writeValue<uint32_t>("PipelineStatisticFlags", pipelineStatistics);
 }
 
-void QueryPool::reset(Context& context){
+void QueryPool::reset(){
     if(_queryPool)
-        vkResetQueryPool(*context.device, _queryPool, 0, queryCount);
+        vkResetQueryPool(*_device, _queryPool, 0, queryCount);
 }
 
-std::vector<uint32_t> QueryPool::getResults(Context& context){
+std::vector<uint32_t> QueryPool::getResults(){
     std::vector<uint32_t> res(queryCount);
-    if (VkResult result = vkGetQueryPoolResults(*context.device, _queryPool, 0, queryCount, queryCount + sizeof(uint32_t), res.data(), sizeof(uint32_t), 0); result != VK_SUCCESS){
+    if (VkResult result = vkGetQueryPoolResults(*_device, _queryPool, 0, queryCount, queryCount * sizeof(uint32_t), res.data(), sizeof(uint32_t), 0); result != VK_SUCCESS){
         throw Exception{"Error: Failed to get QueryPool results.", result};
     }
     return res;

--- a/shaders/accumulator.comp
+++ b/shaders/accumulator.comp
@@ -78,7 +78,10 @@ void main(){
 			vec3 prevNor;
 			prevNor.xy = texture(prevNormal, prevPos.xy).xy;
 			prevNor = vec3(sin(prevNor.x) * cos(prevNor.y), sin(prevNor.x) * sin(prevNor.y), cos(prevNor.x));
-			if(true || dot(normal, prevNor) > .7f){	//we do have a point which can be reprojected
+			
+			// TODO: enable this check once normal decompression has been fixed
+			// if(dot(normal, prevNor) > .7f) //we do have a point which can be reprojected
+			{	
 				reprojected = true;
 				prevColor = texture(prevOutput, prevPos.xy).xyz;
 				pixelSpp += texture(prevSampleCounts, prevPos.xy).x;

--- a/shaders/accumulator.comp
+++ b/shaders/accumulator.comp
@@ -1,5 +1,7 @@
 #version 450
 
+#pragma import_defines(SEPARATE_MATRICES)
+
 layout(binding = 0) uniform sampler2D srcImage;
 layout(binding = 1, r32f) uniform image2D depthImage;
 layout(binding = 2, rg32f) uniform image2D normalImage;
@@ -17,7 +19,7 @@ layout(binding = 13, rgba16f) uniform image2D illuminationSquared;
 
 layout(push_constant) uniform PushConstants 
 {
-	mat4 view;
+	mat4 view;			//for separate matrices view is the inverse projection matrix
 	mat4 inverseView;
 	mat4 prevView;
     vec4 prevOrigin;

--- a/shaders/accumulator.comp
+++ b/shaders/accumulator.comp
@@ -41,18 +41,29 @@ void main(){
 	float truePrevDepth;
 	bool reprojected = false;
 	float pixelSpp = 1.0 / 256.0; //has to be normalized as only floating point 8 bit interp is supported
+    float depth = imageLoad(depthImage, ivec2(gl_GlobalInvocationID.xy)).x;
+#ifdef SEPARATE_MATRICES
+	mat4 proj = inverse(camParams.view);
+	vec4 pos = camParams.inverseView[3];
+	pos.w = 1;
+	vec2 pixelCenter = vec2(gl_GlobalInvocationID.xy) + vec2(.5);
+	vec2 clipSpaceCoord = pixelCenter/vec2(textureSize(srcImage, 0).xy) * 2.0 - 1.0;
+	vec4 dir = camParams.view * vec4(clipSpaceCoord, 1, 1);
+	dir = camParams.inverseView * vec4(normalize(dir.xyz), 0);
+	vec4 p = pos + depth * dir;
+	vec4 prevPos = proj * camParams.prevView * p;
+#elif
     vec4 curOrigin = camParams.inverseView[2];
     curOrigin /= curOrigin.w;
-    vec4 prevOrigin = camParams.prevOrigin;
     vec2 clipSpaceCoord = ((vec2(gl_GlobalInvocationID.xy) + vec2(.5)) / vec2(imageSize)) * 2 - 1;
     vec4 curDir = camParams.inverseView * vec4(clipSpaceCoord.x, clipSpaceCoord.y, 1, 1);
 	curDir /= curDir.w + 1e-9;
 
     curDir = -normalize(curDir - curOrigin);
-    float depth = imageLoad(depthImage, ivec2(gl_GlobalInvocationID.xy)).x;
 	vec4 p = curOrigin + depth * curDir;
-	float preDepth = length(p.xyz - prevOrigin.xyz);
 	vec4 prevPos = camParams.prevView * p;
+#endif
+	float preDepth = length(p.xyz - camParams.prevOrigin.xyz);
 	prevPos /= prevPos.w; // xy now holds the prev image position
 	prevPos.xy += 1;
 	prevPos.xy *= .5;
@@ -67,7 +78,7 @@ void main(){
 			vec3 prevNor;
 			prevNor.xy = texture(prevNormal, prevPos.xy).xy;
 			prevNor = vec3(sin(prevNor.x) * cos(prevNor.y), sin(prevNor.x) * sin(prevNor.y), cos(prevNor.x));
-			if(dot(normal, prevNor) > .7f){	//we do have a point which can be reprojected
+			if(true || dot(normal, prevNor) > .7f){	//we do have a point which can be reprojected
 				reprojected = true;
 				prevColor = texture(prevOutput, prevPos.xy).xyz;
 				pixelSpp += texture(prevSampleCounts, prevPos.xy).x;

--- a/shaders/accumulator.comp
+++ b/shaders/accumulator.comp
@@ -52,7 +52,7 @@ void main(){
 	dir = camParams.inverseView * vec4(normalize(dir.xyz), 0);
 	vec4 p = pos + depth * dir;
 	vec4 prevPos = proj * camParams.prevView * p;
-#elif
+#else
     vec4 curOrigin = camParams.inverseView[2];
     curOrigin /= curOrigin.w;
     vec2 clipSpaceCoord = ((vec2(gl_GlobalInvocationID.xy) + vec2(.5)) / vec2(imageSize)) * 2 - 1;

--- a/shaders/brdf.glsl
+++ b/shaders/brdf.glsl
@@ -110,6 +110,13 @@ float geometricOcclusion(PBRInfo pbrInputs)
     float attenuationL = 2.0 * NdotL / (NdotL + sqrt(r + (1.0 - r) * (NdotL * NdotL)));
     float attenuationV = 2.0 * NdotV / (NdotV + sqrt(r + (1.0 - r) * (NdotV * NdotV)));
     return attenuationL * attenuationV;
+    //float GGXV = NdotL * sqrt(NdotV * NdotV * (1.0 - r) + r);
+    //float GGXL = NdotV * sqrt(NdotL * NdotL * (1.0 - r) + r);
+    //float GGX = GGXV + GGXL;
+    //if(GGX > 0){
+    //    return .5 / GGX;
+    //}
+    //return 0;
 }
 
 // The following equation(s) model the distribution of microfacet normals across the area being drawn (aka D())

--- a/shaders/layoutPTImages.glsl
+++ b/shaders/layoutPTImages.glsl
@@ -12,24 +12,6 @@ layout(binding = 17, rgba8) uniform image2D materialImage;
 layout(binding = 18, rgba8) uniform image2D albedoImage;
 #endif
 
-#ifdef PREV_GBUFFER
-layout(binding = 19) uniform sampler2D prevDepth;
-layout(binding = 20) uniform sampler2D prevNormal;
-layout(binding = 21, r16f) uniform image2D motion;
-layout(binding = 22, r8) uniform image2D sampleCounts;
-layout(binding = 24) uniform sampler2D prevSampleCounts;
-#endif
-
-#ifdef DEMOD_ILLUMINATION
-layout(binding = 23) uniform sampler2D prevOutput;
-layout(binding = 25, rgba16f) uniform image2D illumination;
-#endif
-
-#ifdef DEMOD_ILLUMINATION_SQUARED
-layout(binding = 27, rgba16f) uniform image2D illuminationSquared;
-layout(binding = 28) uniform sampler2D prevIlluminationSquared;
-#endif
-
 #ifdef DEMOD_ILLUMINATION_FLOAT
 layout(binding = 25, rgba32f) uniform image2D illumination;
 #endif

--- a/shaders/layoutPTImages.glsl
+++ b/shaders/layoutPTImages.glsl
@@ -30,4 +30,8 @@ layout(binding = 27, rgba16f) uniform image2D illuminationSquared;
 layout(binding = 28) uniform sampler2D prevIlluminationSquared;
 #endif
 
+#ifdef DEMOD_ILLUMINATION_FLOAT
+layout(binding = 25, rgba32f) uniform image2D illumination;
+#endif
+
 #endif //LAYOUTPTIMAGES_H

--- a/shaders/ptMiss.rmiss
+++ b/shaders/ptMiss.rmiss
@@ -8,8 +8,18 @@ layout(location = 1) rayPayloadInEXT RayPayload rayPayload;
 void main()
 {
     rayPayload.position = vec3(1.0e10);
+    rayPayload.category_id = uint(-1);
     rayPayload.si.normal = vec3(1);
     rayPayload.si.emissiveColor = vec3(0);
     rayPayload.si.diffuseColor = vec3(0);
     rayPayload.si.specularColor = vec3(0);
+    rayPayload.si.perceptualRoughness = 0;
+    rayPayload.si.metalness = 0;
+    rayPayload.si.alphaRoughness = 0;
+    rayPayload.si.illuminationType = 0;
+    rayPayload.si.reflectance0 = vec3(0);
+    rayPayload.si.reflectance90 = vec3(0);
+    rayPayload.si.transmissiveColor = vec3(0);
+    rayPayload.si.basis = mat3(0);
+    rayPayload.si.indexOfRefraction = 1;
 }

--- a/shaders/ptRaygen.rgen
+++ b/shaders/ptRaygen.rgen
@@ -47,7 +47,6 @@ void main(){
 	// --------------------------------------------------------------------
 	vec3 curAlbedo = (rayPayload.si.diffuseColor + rayPayload.si.specularColor).xyz;
 	float depth = distance(rayPayload.position, worldSpacePos.xyz);
-	vec3 pp = rayPayload.si.normal.xyz;
 	vec3 curNorm = rayPayload.si.normal;
 #ifdef GBUFFER
 	imageStore(depthImage, ivec2(gl_LaunchIDEXT.xy), vec4(depth));

--- a/shaders/ptRaygen.rgen
+++ b/shaders/ptRaygen.rgen
@@ -2,7 +2,7 @@
 #extension GL_EXT_ray_tracing : enable
 #extension GL_GOOGLE_include_directive : enable
 
-#pragma import_defines (FINAL_IMAGE, FINAL_IMAGE_HQ, GBUFFER, PREV_GBUFFER, DEMOD_ILLUMINATION, DEMOD_ILLUMINATION_SQUARED, LIGHT_SAMPLE_SURFACE_STRENGTH, LIGHT_SAMPLE_LIGHT_STRENGTH, DEMOD_ILLUMINATION_FLOAT)
+#pragma import_defines (FINAL_IMAGE, FINAL_IMAGE_HQ, GBUFFER, LIGHT_SAMPLE_SURFACE_STRENGTH, LIGHT_SAMPLE_LIGHT_STRENGTH, DEMOD_ILLUMINATION_FLOAT)
 
 #include "ptStructures.glsl"
 #include "layoutPTAccel.glsl"
@@ -60,56 +60,6 @@ void main(){
 #endif
 
     // --------------------------------------------------------------------
-	// accumulation information
-	// --------------------------------------------------------------------
- 	vec3 prevColor;
-	vec3 prevColorSquared;
-	float truePrevDepth;
-	bool reprojected = false;
-	float pixelSpp = 1.0 / 256.0; //has to be normalized as only floating point 8 bit interp is supported
-#if defined PREV_GBUFFER && defined GBUFFER && (defined DEMOD_ILLUMINATION || defined DEMOD_ILLUMINATION_SQUARED)
-	mat4 prevProj = inverse(camParams.inverseProjectionMatrix);
-	vec4 p = vec4(rayPayload.position, 1);
-	vec4 prevPos = camParams.prevView * p;
-	float preDepth = length(prevPos.xyz);
-	prevPos = prevProj * prevPos;
-	prevPos /= prevPos.w; // xy now holds the prev image position
-	prevPos.xy += 1;
-	prevPos.xy *= .5;
-	prevPos.xy *= vec2(gl_LaunchSizeEXT.xy) / vec2(gl_LaunchSizeEXT.xy - .5);
-	ivec2 prevPixelIndex = ivec2(prevPos.xy * (gl_LaunchSizeEXT.xy - vec2(1)) + .5f);
-	if(isinf(rayPayload.position.x)) pixelSpp = 0;
-	if(camParams.frameNumber > 0 && !isinf(rayPayload.position.x)){
-		//depth check
-		truePrevDepth = texture(prevDepth, prevPos.xy).x;
-		float depthDissim = (truePrevDepth / preDepth) - 1;	//using relative error of depths to blend pixels further away form camera together
-		if(all(greaterThanEqual(prevPos.xy, vec2(0))) && all(lessThanEqual(prevPos.xy, vec2(1))) && abs(depthDissim) <= .05f){		//dissimilarity in depth values shoudl be smaller than 1%
-			//normal check
-			vec3 prevNor;
-			prevNor.xy = texture(prevNormal, prevPos.xy).xy;
-			prevNor = vec3(sin(prevNor.x) * cos(prevNor.y), sin(prevNor.x) * sin(prevNor.y), cos(prevNor.x));
-			if(abs(dot(rayPayload.si.normal, prevNor)) > .1f){	//we do have a point which can be reprojected
-				reprojected = true;
-			#ifdef DEMOD_ILLUMINATION
-				prevColor = texture(prevOutput, prevPos.xy).xyz;
-			#endif
-			#ifdef DEMOD_ILLUMINATION_SQUARED
-				prevColorSquared = texture(prevIlluminationSquared, prevPos.xy).xyz;
-			#endif
-				pixelSpp += texture(prevSampleCounts, prevPos.xy).x;
-			}
-		}
-	}
-	if(reprojected){
-		imageStore(motion, ivec2(gl_LaunchIDEXT.xy), vec4(prevPos.xy, 1, 1));
-	}
-	else{
-		imageStore(motion, ivec2(gl_LaunchIDEXT.xy), vec4(-1));
-	}
-	imageStore(sampleCounts, ivec2(gl_LaunchIDEXT.xy), vec4(pixelSpp));
-#endif
-
-    // --------------------------------------------------------------------
 	//depth recursion
 	// --------------------------------------------------------------------
 #if defined FINAL_IMAGE || defined DEMOD_ILLUMINATION || defined DEMOD_ILLUMINATION_SQUARED || defined DEMOD_ILLUMINATION_FLOAT
@@ -129,23 +79,6 @@ void main(){
 	// final color calculations
 	// --------------------------------------------------------------------
 	finalColor = clamp(finalColor, vec3(0), vec3(c_MaxRadiance));
-#if defined DEMOD_ILLUMINATION || defined DEMOD_ILLUMINATION_SQUARED
-	vec3 demodulated = finalColor;
-	if(!isinf(rayPayload.position.x))
-		demodulated = min(finalColor / (curAlbedo + vec3(EPSILON)), vec3(1e3));	// epsilon added to avoid divion by 0 (when color is remodulated, epsilon is added to albedo)
-	vec3 demodSquared = demodulated * demodulated;
-	if(reprojected){
-		float blendAlpha = max(1.f / (pixelSpp * 256.0), BLEND_ALPHA);
-		demodulated = mix(prevColor, demodulated, blendAlpha);
-		demodSquared = mix(prevColorSquared, demodSquared, blendAlpha);
-	}
-	#ifdef DEMOD_ILLUMINATION
-	imageStore(illumination, ivec2(gl_LaunchIDEXT.xy), vec4(demodulated, 1));
-	#endif
-	#ifdef DEMOD_ILLUMINATION_SQUARED
-	imageStore(illuminationSquared, ivec2(gl_LaunchIDEXT.xy), vec4(demodSquared, 1));
-	#endif
-#endif
 
 #if defined DEMOD_ILLUMINATION_FLOAT
 	vec3 demodulated = finalColor;

--- a/shaders/ptRaygen.rgen
+++ b/shaders/ptRaygen.rgen
@@ -2,7 +2,7 @@
 #extension GL_EXT_ray_tracing : enable
 #extension GL_GOOGLE_include_directive : enable
 
-#pragma import_defines (FINAL_IMAGE, FINAL_IMAGE_HQ, GBUFFER, PREV_GBUFFER, DEMOD_ILLUMINATION, DEMOD_ILLUMINATION_SQUARED, LIGHT_SAMPLE_SURFACE_STRENGTH, LIGHT_SAMPLE_LIGHT_STRENGTH)
+#pragma import_defines (FINAL_IMAGE, FINAL_IMAGE_HQ, GBUFFER, PREV_GBUFFER, DEMOD_ILLUMINATION, DEMOD_ILLUMINATION_SQUARED, LIGHT_SAMPLE_SURFACE_STRENGTH, LIGHT_SAMPLE_LIGHT_STRENGTH, DEMOD_ILLUMINATION_FLOAT)
 
 #include "ptStructures.glsl"
 #include "layoutPTAccel.glsl"
@@ -47,6 +47,7 @@ void main(){
 	// --------------------------------------------------------------------
 	vec3 curAlbedo = (rayPayload.si.diffuseColor + rayPayload.si.specularColor).xyz;
 	float depth = distance(rayPayload.position, worldSpacePos.xyz);
+	vec3 pp = rayPayload.si.normal.xyz;
 	vec3 curNorm = rayPayload.si.normal;
 #ifdef GBUFFER
 	imageStore(depthImage, ivec2(gl_LaunchIDEXT.xy), vec4(depth));
@@ -112,7 +113,7 @@ void main(){
     // --------------------------------------------------------------------
 	//depth recursion
 	// --------------------------------------------------------------------
-#if defined FINAL_IMAGE || defined DEMOD_ILLUMINATION || defined DEMOD_ILLUMINATION_SQUARED
+#if defined FINAL_IMAGE || defined DEMOD_ILLUMINATION || defined DEMOD_ILLUMINATION_SQUARED || defined DEMOD_ILLUMINATION_FLOAT
 	if(rayPayload.si.normal != vec3(1)){
 		int transDepth = 0;
 		for(int i = 0; i < infos.maxRecursionDepth && transDepth < 10; ++i){
@@ -147,6 +148,14 @@ void main(){
 	#endif
 #endif
 
+#if defined DEMOD_ILLUMINATION_FLOAT
+	vec3 demodulated = finalColor;
+	if(!isinf(rayPayload.position.x)){
+		demodulated = min(finalColor / (curAlbedo + vec3(EPSILON)), vec3(1e3));
+	}
+	imageStore(illumination, ivec2(gl_LaunchIDEXT.xy), vec4(demodulated, 1));
+#endif
+
 #ifdef FINAL_IMAGE
 	vec3 prevFrameColor = vec3(1.0/0);
 	if(camParams.sampleNumber > 0){
@@ -157,7 +166,7 @@ void main(){
 
 	finalColor = LINEARtoSRGB(vec4(finalColor, 1)).xyz;
 	finalColor = clamp(finalColor, vec3(0), vec3(1));
-	
+
 	imageStore(outputImage, ivec2(gl_LaunchIDEXT.xy), vec4(finalColor, 1));
 #endif
 }

--- a/source/VulkanPBRT.cpp
+++ b/source/VulkanPBRT.cpp
@@ -27,12 +27,14 @@
 
 #define _DEBUG
 
-class RayTracingPushConstantsValue : public vsg::Inherit<vsg::Value<RayTracingPushConstants>, RayTracingPushConstantsValue>{
-    public:
-    RayTracingPushConstantsValue(){}
+class RayTracingPushConstantsValue : public vsg::Inherit<vsg::Value<RayTracingPushConstants>, RayTracingPushConstantsValue>
+{
+public:
+    RayTracingPushConstantsValue() {}
 };
 
-enum class DenoisingType{
+enum class DenoisingType
+{
     None,
     BMFR,
     BFR,
@@ -40,7 +42,8 @@ enum class DenoisingType{
 };
 DenoisingType denoisingType = DenoisingType::None;
 
-enum class DenoisingBlockSize{
+enum class DenoisingBlockSize
+{
     x8,
     x16,
     x32,
@@ -52,22 +55,25 @@ DenoisingBlockSize denoisingBlockSize = DenoisingBlockSize::x32;
 class LoggingRedirectSentry
 {
 public:
-    LoggingRedirectSentry(std::ostream* outStream, std::streambuf* originalBuffer)
-    	: outStream(outStream), originalBuffer(originalBuffer)
+    LoggingRedirectSentry(std::ostream *outStream, std::streambuf *originalBuffer)
+        : outStream(outStream), originalBuffer(originalBuffer)
     {
     }
     ~LoggingRedirectSentry()
     {
         //reset to standard output
-        outStream->rdbuf(originalBuffer); 
+        outStream->rdbuf(originalBuffer);
     }
+
 private:
-    std::ostream* outStream;
-    std::streambuf* originalBuffer;
+    std::ostream *outStream;
+    std::streambuf *originalBuffer;
 };
 
-int main(int argc, char** argv){
-    try{
+int main(int argc, char **argv)
+{
+    try
+    {
         vsg::CommandLine arguments(&argc, argv);
 
         // load config
@@ -91,7 +97,7 @@ int main(int argc, char** argv){
         LoggingRedirectSentry cerrSenry(&std::cerr, std::cerr.rdbuf());
         std::ofstream out("out_log.txt");
         std::ofstream err_log("err_log.txt");
-        if (arguments.read({ "--log", "-l" }))
+        if (arguments.read({"--log", "-l"}))
         {
             // redirect cout and cerr to log files
             std::cout.rdbuf(out.rdbuf());
@@ -103,8 +109,9 @@ int main(int argc, char** argv){
         windowTraits->debugLayer = arguments.read({"--debug", "-d"});
         windowTraits->apiDumpLayer = arguments.read({"--api", "-a"});
         windowTraits->fullscreen = arguments.read({"--fullscreen", "-fs"});
-        if(arguments.read({"--window", "-w"}, windowTraits->width, windowTraits->height)) windowTraits->fullscreen = false;
-        arguments.read("--screen", windowTraits->screenNum);	
+        if (arguments.read({"--window", "-w"}, windowTraits->width, windowTraits->height))
+            windowTraits->fullscreen = false;
+        arguments.read("--screen", windowTraits->screenNum);
 
         auto numFrames = arguments.value(-1, "-f");
         auto numExportFrames = arguments.value(-1, "-ef");
@@ -132,16 +139,25 @@ int main(int argc, char** argv){
         {
             std::cout << "Missing input parameter \"-i <path_to_model>\"." << std::endl;
         }
-        if(arguments.read("m")) sceneFilename = "models/raytracing_scene.vsgt";
-        if(arguments.errors()) return arguments.writeErrorMessages(std::cerr);
+        if (arguments.read("m"))
+            sceneFilename = "models/raytracing_scene.vsgt";
+        if (arguments.errors())
+            return arguments.writeErrorMessages(std::cerr);
 
         std::string denoisingTypeStr;
-        if(arguments.read("--denoiser", denoisingTypeStr)){
-            if(denoisingTypeStr == "bmfr")     denoisingType = DenoisingType::BMFR;
-            else if(denoisingTypeStr == "bfr") denoisingType = DenoisingType::BFR;
-            else if(denoisingTypeStr == "svgf")denoisingType = DenoisingType::SVG;
-            else if(denoisingTypeStr == "none"){}
-            else std::cout << "Unknown denoising type: " << denoisingTypeStr << std::endl;
+        if (arguments.read("--denoiser", denoisingTypeStr))
+        {
+            if (denoisingTypeStr == "bmfr")
+                denoisingType = DenoisingType::BMFR;
+            else if (denoisingTypeStr == "bfr")
+                denoisingType = DenoisingType::BFR;
+            else if (denoisingTypeStr == "svgf")
+                denoisingType = DenoisingType::SVG;
+            else if (denoisingTypeStr == "none")
+            {
+            }
+            else
+                std::cout << "Unknown denoising type: " << denoisingTypeStr << std::endl;
         }
         bool useTaa = arguments.read("--taa");
         bool useFlyNavigation = arguments.read("--fly");
@@ -154,14 +170,13 @@ int main(int argc, char** argv){
         windowTraits->queueFlags = VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT;
         windowTraits->imageAvailableSemaphoreWaitFlag = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;
         windowTraits->swapchainPreferences.imageUsage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
-        windowTraits->deviceExtensionNames = {VK_KHR_GET_MEMORY_REQUIREMENTS_2_EXTENSION_NAME, VK_KHR_RAY_TRACING_PIPELINE_EXTENSION_NAME, VK_KHR_ACCELERATION_STRUCTURE_EXTENSION_NAME
-        , VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME, VK_KHR_DEFERRED_HOST_OPERATIONS_EXTENSION_NAME, VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME, VK_KHR_SPIRV_1_4_EXTENSION_NAME, VK_KHR_SHADER_FLOAT_CONTROLS_EXTENSION_NAME};
+        windowTraits->deviceExtensionNames = {VK_KHR_GET_MEMORY_REQUIREMENTS_2_EXTENSION_NAME, VK_KHR_RAY_TRACING_PIPELINE_EXTENSION_NAME, VK_KHR_ACCELERATION_STRUCTURE_EXTENSION_NAME, VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME, VK_KHR_DEFERRED_HOST_OPERATIONS_EXTENSION_NAME, VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME, VK_KHR_SPIRV_1_4_EXTENSION_NAME, VK_KHR_SHADER_FLOAT_CONTROLS_EXTENSION_NAME};
         windowTraits->vulkanVersion = VK_API_VERSION_1_2;
-        auto& enabledAccelerationStructureFeatures = windowTraits->deviceFeatures->get<VkPhysicalDeviceAccelerationStructureFeaturesKHR, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_FEATURES_KHR>();
-        auto& enabledRayTracingPipelineFeatures = windowTraits->deviceFeatures->get<VkPhysicalDeviceRayTracingPipelineFeaturesKHR, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_FEATURES_KHR>();
+        auto &enabledAccelerationStructureFeatures = windowTraits->deviceFeatures->get<VkPhysicalDeviceAccelerationStructureFeaturesKHR, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_FEATURES_KHR>();
+        auto &enabledRayTracingPipelineFeatures = windowTraits->deviceFeatures->get<VkPhysicalDeviceRayTracingPipelineFeaturesKHR, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_FEATURES_KHR>();
         enabledAccelerationStructureFeatures.accelerationStructure = VK_TRUE;
         enabledRayTracingPipelineFeatures.rayTracingPipeline = VK_TRUE;
-        auto& enabledPhysicalDeviceVk12Feature = windowTraits->deviceFeatures->get<VkPhysicalDeviceVulkan12Features, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES>();
+        auto &enabledPhysicalDeviceVk12Feature = windowTraits->deviceFeatures->get<VkPhysicalDeviceVulkan12Features, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES>();
         enabledPhysicalDeviceVk12Feature.runtimeDescriptorArray = VK_TRUE;
         enabledPhysicalDeviceVk12Feature.bufferDeviceAddress = VK_TRUE;
         enabledPhysicalDeviceVk12Feature.descriptorIndexing = VK_TRUE;
@@ -173,60 +188,76 @@ int main(int argc, char** argv){
         std::vector<vsg::ref_ptr<OfflineGBuffer>> offlineGBuffers;
         std::vector<vsg::ref_ptr<OfflineIllumination>> offlineIlluminations;
         std::vector<DoubleMatrix> cameraMatrices;
-        if(!externalRenderings){
+        if (!externalRenderings)
+        {
             AI3DFrontImporter::ReadConfig(config_json);
             auto options = vsg::Options::create(vsgXchange::assimp::create(), vsgXchange::dds::create(), vsgXchange::stbi::create()); //using the assimp loader
             loaded_scene = vsg::read_cast<vsg::Node>(sceneFilename, options);
-            if(!loaded_scene){
+            if (!loaded_scene)
+            {
                 std::cout << "Scene not found: " << sceneFilename << std::endl;
                 return 1;
             }
         }
-        else{
-            if(numFrames <= 0){
+        else
+        {
+            if (numFrames <= 0)
+            {
                 std::cout << "No number of frames given. For usage of external GBuffer and Illumination information use \"-f\" to inform about the number of frames." << std::endl;
                 return 1;
             }
-            if(matricesPath.empty()){
+            if (matricesPath.empty())
+            {
                 std::cout << "Camera matrices are missing. Insert location of file with camera information via \"--matrices\"." << std::endl;
                 return 1;
             }
             cameraMatrices = MatrixIO::importMatrices(matricesPath);
-            if(cameraMatrices.empty()){
+            if (cameraMatrices.empty())
+            {
                 std::cout << "Camera matrices could not be loaded" << std::endl;
                 return 1;
             }
-            if(positionPath.size()){
+            if (positionPath.size())
+            {
                 offlineGBuffers = GBufferIO::importGBufferPosition(positionPath, normalPath, materialPath, albedoPath, cameraMatrices, numFrames);
             }
-            else{
+            else
+            {
                 offlineGBuffers = GBufferIO::importGBufferDepth(depthPath, normalPath, materialPath, albedoPath, numFrames);
             }
             offlineIlluminations = IlluminationBufferIO::importIllumination(illuminationPath, numFrames);
             windowTraits->width = offlineGBuffers[0]->depth->width();
             windowTraits->height = offlineGBuffers[0]->depth->height();
         }
-        if(exportIllumination){
-            if(numFrames <= 0){
+        if (exportIllumination)
+        {
+            if (numFrames <= 0)
+            {
                 std::cout << "No number of frames given. For usage of Illumination export use \"-f\" to inform about the number of frames." << std::endl;
                 return 1;
             }
-            if(offlineIlluminations.empty()){
+            if (offlineIlluminations.empty())
+            {
                 offlineIlluminations.resize(numFrames);
-                for(auto& i: offlineIlluminations){
+                for (auto &i : offlineIlluminations)
+                {
                     i = OfflineIllumination::create();
                     i->noisy = vsg::vec4Array2D::create(windowTraits->width, windowTraits->height);
                 }
             }
         }
-        if(exportGBuffer){
-            if(numFrames <= 0){
+        if (exportGBuffer)
+        {
+            if (numFrames <= 0)
+            {
                 std::cout << "No number of frames given. For usage of GBuffer export use \"-f\" to inform about the number of frames." << std::endl;
                 return 1;
             }
-            if(offlineGBuffers.empty()){
+            if (offlineGBuffers.empty())
+            {
                 offlineGBuffers.resize(numFrames);
-                for(auto& i: offlineGBuffers){
+                for (auto &i : offlineGBuffers)
+                {
                     i = OfflineGBuffer::create();
                     i->depth = vsg::floatArray2D::create(windowTraits->width, windowTraits->height);
                     i->normal = vsg::vec2Array2D::create(windowTraits->width, windowTraits->height);
@@ -235,16 +266,19 @@ int main(int argc, char** argv){
                 }
             }
         }
-        if(storeMatrices){
+        if (storeMatrices)
+        {
             cameraMatrices.resize(numFrames);
-            for(auto& matrix: cameraMatrices){
+            for (auto &matrix : cameraMatrices)
+            {
                 matrix.proj = vsg::mat4();
                 matrix.invProj = vsg::mat4();
             }
         }
 
         auto window = vsg::Window::create(windowTraits);
-        if(!window){
+        if (!window)
+        {
             std::cout << "Could not create windows." << std::endl;
             return 1;
         }
@@ -255,7 +289,7 @@ int main(int argc, char** argv){
 
         //setting a custom render pass for imgui non clear rendering
         {
-            vsg::AttachmentDescription  colorAttachment = vsg::defaultColorAttachment(window->surfaceFormat().format);
+            vsg::AttachmentDescription colorAttachment = vsg::defaultColorAttachment(window->surfaceFormat().format);
             colorAttachment.loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
             colorAttachment.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
             colorAttachment.initialLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
@@ -265,22 +299,22 @@ int main(int argc, char** argv){
             vsg::RenderPass::Attachments attachments{
                 colorAttachment,
                 depthAttachment};
-    
+
             VkAttachmentReference colorAttachmentRef = {};
             colorAttachmentRef.attachment = 0;
             colorAttachmentRef.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
-    
+
             VkAttachmentReference depthAttachmentRef = {};
             depthAttachmentRef.attachment = 1;
             depthAttachmentRef.layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
-    
+
             vsg::SubpassDescription subpass = {};
             subpass.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
             subpass.colorAttachments.emplace_back(colorAttachmentRef);
             subpass.depthStencilAttachments.emplace_back(depthAttachmentRef);
-    
+
             vsg::RenderPass::Subpasses subpasses{subpass};
-    
+
             // image layout transition
             VkSubpassDependency colorDependency = {};
             colorDependency.srcSubpass = VK_SUBPASS_EXTERNAL;
@@ -290,7 +324,7 @@ int main(int argc, char** argv){
             colorDependency.srcAccessMask = 0;
             colorDependency.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
             colorDependency.dependencyFlags = 0;
-    
+
             // depth buffer is shared between swap chain images
             VkSubpassDependency depthDependency = {};
             depthDependency.srcSubpass = VK_SUBPASS_EXTERNAL;
@@ -300,9 +334,9 @@ int main(int argc, char** argv){
             depthDependency.srcAccessMask = VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
             depthDependency.dstAccessMask = VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT | VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
             depthDependency.dependencyFlags = 0;
-    
+
             vsg::RenderPass::Dependencies dependencies{colorDependency, depthDependency};
-    
+
             auto renderPass = vsg::RenderPass::create(device, attachments, subpasses, dependencies);
             window->setRenderPass(renderPass);
         }
@@ -337,7 +371,8 @@ int main(int argc, char** argv){
             writeGBuffer = false;
             illuminationBuffer = IlluminatonBufferFinalFloat::create(windowTraits->width, windowTraits->height);
         }
-        if (exportIllumination && !gBuffer){
+        if (exportIllumination && !gBuffer)
+        {
             writeGBuffer = true;
             gBuffer = GBuffer::create(windowTraits->width, windowTraits->height);
         }
@@ -345,25 +380,31 @@ int main(int argc, char** argv){
         {
             // TODO: need the velocity buffer
         }
-        
+
         // raytracing pipeline setup
         uint32_t maxRecursionDepth = 2;
         vsg::ref_ptr<PBRTPipeline> pbrtPipeline;
-        if(!externalRenderings)
+        if (!externalRenderings)
         {
             pbrtPipeline = PBRTPipeline::create(loaded_scene, gBuffer, accumulationBuffer, illuminationBuffer, writeGBuffer, RayTracingRayOrigin::CAMERA);
 
             // setup tlas
             vsg::BuildAccelerationStructureTraversal buildAccelStruct(device);
             loaded_scene->accept(buildAccelStruct);
-            pbrtPipeline->setTlas(buildAccelStruct.tlas);      
+            pbrtPipeline->setTlas(buildAccelStruct.tlas);
         }
-        else{
-            if(!gBuffer)
+        else
+        {
+            if (!gBuffer)
                 gBuffer = GBuffer::create(offlineGBuffers[0]->depth->width(), offlineGBuffers[0]->depth->height());
-            switch(offlineIlluminations[0]->noisy->getLayout().format){
-            case VK_FORMAT_R16G16B16A16_SFLOAT: illuminationBuffer = IlluminationBufferDemodulated::create(offlineIlluminations[0]->noisy->width(), offlineIlluminations[0]->noisy->height()); break;
-            case VK_FORMAT_R32G32B32A32_SFLOAT: illuminationBuffer = IlluminationBufferDemodulatedFloat::create(offlineIlluminations[0]->noisy->width(), offlineIlluminations[0]->noisy->height()); break;
+            switch (offlineIlluminations[0]->noisy->getLayout().format)
+            {
+            case VK_FORMAT_R16G16B16A16_SFLOAT:
+                illuminationBuffer = IlluminationBufferDemodulated::create(offlineIlluminations[0]->noisy->width(), offlineIlluminations[0]->noisy->height());
+                break;
+            case VK_FORMAT_R32G32B32A32_SFLOAT:
+                illuminationBuffer = IlluminationBufferDemodulatedFloat::create(offlineIlluminations[0]->noisy->width(), offlineIlluminations[0]->noisy->height());
+                break;
             default:
                 std::cout << "Offline illumination buffer image format not compatible" << std::endl;
                 return 1;
@@ -377,8 +418,9 @@ int main(int argc, char** argv){
         auto offlineGBufferStager = OfflineGBuffer::create();
         auto offlineIlluminationBufferStager = OfflineIllumination::create();
         vsg::ref_ptr<vsg::QueryPool> queryPool;
-        if(pbrtPipeline){
-            queryPool = vsg::QueryPool::create();   //standard init has 1 timestamp place
+        if (pbrtPipeline)
+        {
+            queryPool = vsg::QueryPool::create(); //standard init has 1 timestamp place
             queryPool->queryCount = 2;
             queryPool->compile(imageLayoutCompile.context);
             auto resetQuery = vsg::ResetQueryPool::create(queryPool);
@@ -390,8 +432,10 @@ int main(int argc, char** argv){
             commands->addChild(write2);
             illuminationBuffer = pbrtPipeline->getIlluminationBuffer();
         }
-        else{
-            if(offlineGBuffers.size() < numFrames || offlineIlluminations.size() < numFrames){
+        else
+        {
+            if (offlineGBuffers.size() < numFrames || offlineIlluminations.size() < numFrames)
+            {
                 std::cout << "Missing offline GBuffer or offline Illumination Buffer info" << std::endl;
                 return 1;
             }
@@ -400,14 +444,15 @@ int main(int argc, char** argv){
         }
 
         vsg::ref_ptr<Accumulator> accumulator;
-        if(externalRenderings && denoisingType != DenoisingType::None){
-            queryPool = vsg::QueryPool::create();   //standard init has 1 timestamp place
+        if (externalRenderings && denoisingType != DenoisingType::None)
+        {
+            queryPool = vsg::QueryPool::create(); //standard init has 1 timestamp place
             queryPool->queryCount = 2;
             queryPool->compile(imageLayoutCompile.context);
             auto resetQuery = vsg::ResetQueryPool::create(queryPool);
             auto write1 = vsg::WriteTimestamp::create(queryPool, 0, VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR);
             auto write2 = vsg::WriteTimestamp::create(queryPool, 1, VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR);
-            accumulator = Accumulator::create(gBuffer, illuminationBuffer, cameraMatrices);
+            accumulator = Accumulator::create(gBuffer, illuminationBuffer, false);
             commands->addChild(resetQuery);
             commands->addChild(write1);
             accumulator->addDispatchToCommandGraph(commands);
@@ -415,16 +460,21 @@ int main(int argc, char** argv){
             accumulationBuffer = accumulator->accumulationBuffer;
             illuminationBuffer->compile(imageLayoutCompile.context);
             illuminationBuffer->updateImageLayouts(imageLayoutCompile.context);
-            illuminationBuffer = accumulator->accumulatedIllumination;  //swap illumination buffer to accumulated illumination for correct use in the following pipelines
+            illuminationBuffer = accumulator->accumulatedIllumination; //swap illumination buffer to accumulated illumination for correct use in the following pipelines
+        }
+        else{
+            accumulator = Accumulator::create(gBuffer, illuminationBuffer, true);
         }
 
-        vsg::ref_ptr<vsg::DescriptorImage> finalDescriptorImage;  
-        switch(denoisingType){
+        vsg::ref_ptr<vsg::DescriptorImage> finalDescriptorImage;
+        switch (denoisingType)
+        {
         case DenoisingType::None:
             finalDescriptorImage = illuminationBuffer->illuminationImages[0];
             break;
         case DenoisingType::BFR:
-            switch(denoisingBlockSize){
+            switch (denoisingBlockSize)
+            {
             case DenoisingBlockSize::x8:
             {
                 auto bfr8 = BFR::create(windowTraits->width, windowTraits->height, 8, 8, gBuffer, illuminationBuffer, accumulationBuffer);
@@ -457,9 +507,9 @@ int main(int argc, char** argv){
                 auto bfr8 = BFR::create(windowTraits->width, windowTraits->height, 8, 8, gBuffer, illuminationBuffer, accumulationBuffer);
                 auto bfr16 = BFR::create(windowTraits->width, windowTraits->height, 16, 16, gBuffer, illuminationBuffer, accumulationBuffer);
                 auto bfr32 = BFR::create(windowTraits->width, windowTraits->height, 32, 32, gBuffer, illuminationBuffer, accumulationBuffer);
-                auto blender = BFRBlender::create(windowTraits->width, windowTraits->height, 
-                                        illuminationBuffer->illuminationImages[0], illuminationBuffer->illuminationImages[1],
-                                        bfr8->getFinalDescriptorImage(), bfr16->getFinalDescriptorImage(), bfr32->getFinalDescriptorImage());
+                auto blender = BFRBlender::create(windowTraits->width, windowTraits->height,
+                                                  illuminationBuffer->illuminationImages[0], illuminationBuffer->illuminationImages[1],
+                                                  bfr8->getFinalDescriptorImage(), bfr16->getFinalDescriptorImage(), bfr32->getFinalDescriptorImage());
                 bfr8->compile(imageLayoutCompile.context);
                 bfr8->updateImageLayouts(imageLayoutCompile.context);
                 bfr16->compile(imageLayoutCompile.context);
@@ -478,7 +528,8 @@ int main(int argc, char** argv){
             }
             break;
         case DenoisingType::BMFR:
-            switch(denoisingBlockSize){
+            switch (denoisingBlockSize)
+            {
             case DenoisingBlockSize::x8:
             {
                 auto bmfr8 = BMFR::create(windowTraits->width, windowTraits->height, 8, 8, gBuffer, illuminationBuffer, accumulationBuffer, 64);
@@ -510,9 +561,9 @@ int main(int argc, char** argv){
                 auto bmfr8 = BMFR::create(windowTraits->width, windowTraits->height, 8, 8, gBuffer, illuminationBuffer, accumulationBuffer, 64);
                 auto bmfr16 = BMFR::create(windowTraits->width, windowTraits->height, 16, 16, gBuffer, illuminationBuffer, accumulationBuffer);
                 auto bmfr32 = BMFR::create(windowTraits->width, windowTraits->height, 32, 32, gBuffer, illuminationBuffer, accumulationBuffer);
-                auto blender = BFRBlender::create(windowTraits->width, windowTraits->height, 
-                                        illuminationBuffer->illuminationImages[1], illuminationBuffer->illuminationImages[2],
-                                        bmfr8->getFinalDescriptorImage(), bmfr16->getFinalDescriptorImage(), bmfr32->getFinalDescriptorImage());
+                auto blender = BFRBlender::create(windowTraits->width, windowTraits->height,
+                                                  illuminationBuffer->illuminationImages[1], illuminationBuffer->illuminationImages[2],
+                                                  bmfr8->getFinalDescriptorImage(), bmfr16->getFinalDescriptorImage(), bmfr32->getFinalDescriptorImage());
                 bmfr8->compile(imageLayoutCompile.context);
                 bmfr8->updateImageLayouts(imageLayoutCompile.context);
                 bmfr16->compile(imageLayoutCompile.context);
@@ -534,28 +585,34 @@ int main(int argc, char** argv){
             break;
         }
 
-        if(useTaa && accumulationBuffer){
+        if (useTaa && accumulationBuffer)
+        {
             auto taa = Taa::create(windowTraits->width, windowTraits->height, 16, 16, gBuffer, accumulationBuffer, finalDescriptorImage);
             taa->compile(imageLayoutCompile.context);
             taa->updateImageLayouts(imageLayoutCompile.context);
             taa->addDispatchToCommandGraph(commands);
             finalDescriptorImage = taa->getFinalDescriptorImage();
         }
-        if(exportGBuffer){
-            if(!gBuffer){
+        if (exportGBuffer)
+        {
+            if (!gBuffer)
+            {
                 std::cout << "GBuffer information not available, export not possible" << std::endl;
                 return 1;
             }
             offlineGBufferStager->downloadFromGBufferCommand(gBuffer, commands, imageLayoutCompile.context);
         }
-        if(exportIllumination){
-            if(finalDescriptorImage->imageInfoList[0]->imageView->image->format != VK_FORMAT_R32G32B32A32_SFLOAT){
+        if (exportIllumination)
+        {
+            if (finalDescriptorImage->imageInfoList[0]->imageView->image->format != VK_FORMAT_R32G32B32A32_SFLOAT)
+            {
                 std::cout << "Final image layout is not compatible illumination buffer export" << std::endl;
                 return 1;
             }
             offlineIlluminationBufferStager->downloadFromIlluminationBufferCommand(illuminationBuffer, commands, imageLayoutCompile.context);
         }
-        if(finalDescriptorImage->imageInfoList[0]->imageView->image->format != VK_FORMAT_B8G8R8A8_UNORM){
+        if (finalDescriptorImage->imageInfoList[0]->imageView->image->format != VK_FORMAT_B8G8R8A8_UNORM)
+        {
             auto converter = FormatConverter::create(finalDescriptorImage->imageInfoList[0]->imageView, VK_FORMAT_B8G8R8A8_UNORM);
             converter->compileImages(imageLayoutCompile.context);
             converter->updateImageLayouts(imageLayoutCompile.context);
@@ -579,7 +636,7 @@ int main(int argc, char** argv){
         }
         imageLayoutCompile.context.record();
 
-        if (accumulationBuffer) 
+        if (accumulationBuffer)
         {
             accumulationBuffer->copyToBackImages(commands, gBuffer, illuminationBuffer);
         }
@@ -597,17 +654,17 @@ int main(int argc, char** argv){
         auto viewport = vsg::ViewportState::create(0, 0, windowTraits->width, windowTraits->height);
         auto camera = vsg::Camera::create(perspective, lookAt, viewport);
         auto renderGraph = vsg::createRenderGraphForView(window, camera, vsgImGui::RenderImGui::create(window, Gui(guiValues))); // render graph for gui rendering
-        renderGraph->clearValues.clear();   //removing clear values to avoid clearing the raytraced image
+        renderGraph->clearValues.clear();                                                                                        //removing clear values to avoid clearing the raytraced image
 
         auto commandGraph = vsg::CommandGraph::create(window);
         commandGraph->addChild(commands);
         commandGraph->addChild(vsg::CopyImageViewToWindow::create(finalDescriptorImage->imageInfoList[0]->imageView, window));
         commandGraph->addChild(renderGraph);
-        
+
         //close handler to close and imgui handler to forward to imgui
         viewer->addEventHandler(vsgImGui::SendEventsToImGui::create());
         viewer->addEventHandler(vsg::CloseHandler::create(viewer));
-        if(useFlyNavigation)
+        if (useFlyNavigation)
             viewer->addEventHandler(vsg::FlyNavigation::create(camera));
         else
             viewer->addEventHandler(vsg::Trackball::create(camera));
@@ -619,16 +676,25 @@ int main(int argc, char** argv){
 
         int numFramesC = numFrames;
         int exportCount = -1;
-        while(viewer->advanceToNextFrame() && (numFrames < 0 || (numFrames--) > 0)){
-            if(externalRenderings)
+        while (viewer->advanceToNextFrame() && (numFrames < 0 || (numFrames--) > 0))
+        {
+            if (externalRenderings)
             {
-                int frame = offlineGBuffers.size() - 1 - numFrames;     //invert numFrames as it is counting down
+                int frame = offlineGBuffers.size() - 1 - numFrames; //invert numFrames as it is counting down
                 offlineGBufferStager->transferStagingDataFrom(offlineGBuffers[frame]);
                 offlineIlluminationBufferStager->transferStagingDataFrom(offlineIlluminations[frame]);
-                if(accumulator)
-                    accumulator->setFrameIndex(frame);
+                if (accumulator)
+                    accumulator->setDoubleMatrix(frame, cameraMatrices[frame], cameraMatrices[frame ? frame - 1 : frame]);
             }
-            
+            else if (accumulator)
+            {
+                DoubleMatrix a{}, b{};
+                a.invView = lookAt->inverse();
+                a.invProj = perspective->inverse();
+                b.view = rayTracingPushConstantsValue->value().prevView;
+                accumulator->setDoubleMatrix(rayTracingPushConstantsValue->value().frameNumber, a, b);
+            }
+
             viewer->handleEvents();
 
             //update push constants
@@ -636,13 +702,15 @@ int main(int argc, char** argv){
 
             rayTracingPushConstantsValue->value().frameNumber++;
             rayTracingPushConstantsValue->value().sampleNumber++;
-            if((vsg::mat4)vsg::lookAt(lookAt->eye, lookAt->center, lookAt->up) != rayTracingPushConstantsValue->value().prevView) rayTracingPushConstantsValue->value().sampleNumber = 0;
+            if ((vsg::mat4)vsg::lookAt(lookAt->eye, lookAt->center, lookAt->up) != rayTracingPushConstantsValue->value().prevView)
+                rayTracingPushConstantsValue->value().sampleNumber = 0;
             guiValues->sampleNumber = rayTracingPushConstantsValue->value().sampleNumber;
 
             viewer->update();
             viewer->recordAndSubmit();
             viewer->present();
-            if(queryPool){
+            if (queryPool)
+            {
                 viewer->deviceWaitIdle();
                 auto results = queryPool->getResults();
                 static double running = 0;
@@ -654,19 +722,23 @@ int main(int argc, char** argv){
 
             rayTracingPushConstantsValue->value().prevView = lookAt->transform();
 
-            if((exportGBuffer || exportIllumination) && rayTracingPushConstantsValue->value().sampleNumber >= samplesPerPixel){
+            if ((exportGBuffer || exportIllumination) && rayTracingPushConstantsValue->value().sampleNumber >= samplesPerPixel)
+            {
                 ++exportCount;
                 viewer->deviceWaitIdle();
             }
-            if(exportIllumination){
+            if (exportIllumination)
+            {
                 int frame = exportCount;
                 offlineIlluminationBufferStager->transferStagingDataTo(offlineIlluminations[frame]);
             }
-            if(exportGBuffer){
+            if (exportGBuffer)
+            {
                 int frame = exportCount;
                 offlineGBufferStager->transferStagingDataTo(offlineGBuffers[frame]);
             }
-            if(storeMatrices){
+            if (storeMatrices)
+            {
                 int frame = exportCount;
                 cameraMatrices[frame].view = lookAt->transform();
                 cameraMatrices[frame].invView = lookAt->inverse();
@@ -677,14 +749,15 @@ int main(int argc, char** argv){
         numFrames = numFramesC;
 
         // exporting all images
-        if(exportGBuffer)
+        if (exportGBuffer)
             GBufferIO::exportGBuffer(exportPositionPath, exportDepthPath, exportNormalPath, exportMaterialPath, exportAlbedoPath, numFrames, offlineGBuffers, cameraMatrices);
-        if(exportIllumination)
+        if (exportIllumination)
             IlluminationBufferIO::exportIllumination(exportIlluminationPath, numFrames, offlineIlluminations);
-        if(exportMatricesPath.size())
+        if (exportMatricesPath.size())
             MatrixIO::exportMatrices(exportMatricesPath, cameraMatrices);
     }
-    catch (const vsg::Exception& e){
+    catch (const vsg::Exception &e)
+    {
         std::cout << e.message << " VkResult = " << e.result << std::endl;
         return 0;
     }

--- a/source/VulkanPBRT.cpp
+++ b/source/VulkanPBRT.cpp
@@ -693,21 +693,10 @@ int main(int argc, char **argv)
             viewer->update();
             viewer->recordAndSubmit();
             viewer->present();
-            if (queryPool)
-            {
-                auto results = queryPool->getResults();
-                static double running = 0;
-                static int count = 0;
-                double a = count / double(++count);
-                running = a * running + (1 - a) * (results[1] - results[0]) / 1e6;
-                if(count > 1) std::cout << "\r";
-                std::cout << running;
-                std::cout.flush();
-            }
 
             rayTracingPushConstantsValue->value().prevView = lookAt->transform();
 
-            if (sample_index >= samplesPerPixel + 1) {
+            if (sample_index + 1 >= samplesPerPixel) {
                 if (exportGBuffer || exportIllumination) {
                     viewer->deviceWaitIdle();
                     if (exportIllumination) {

--- a/source/VulkanPBRT.cpp
+++ b/source/VulkanPBRT.cpp
@@ -385,7 +385,7 @@ int main(int argc, char **argv)
         vsg::ref_ptr<PBRTPipeline> pbrtPipeline;
         if (!externalRenderings)
         {
-            pbrtPipeline = PBRTPipeline::create(loaded_scene, gBuffer, accumulationBuffer, illuminationBuffer, writeGBuffer, RayTracingRayOrigin::CAMERA);
+            pbrtPipeline = PBRTPipeline::create(loaded_scene, gBuffer, illuminationBuffer, writeGBuffer, RayTracingRayOrigin::CAMERA);
 
             // setup tlas
             vsg::BuildAccelerationStructureTraversal buildAccelStruct(device);

--- a/source/VulkanPBRT.cpp
+++ b/source/VulkanPBRT.cpp
@@ -186,7 +186,7 @@ int main(int argc, char **argv)
         vsg::ref_ptr<vsg::Node> loaded_scene;
         std::vector<vsg::ref_ptr<OfflineGBuffer>> offlineGBuffers;
         std::vector<vsg::ref_ptr<OfflineIllumination>> offlineIlluminations;
-        std::vector<DoubleMatrix> cameraMatrices;
+        std::vector<CameraMatrices> cameraMatrices;
         if(!use_external_buffers){
             AI3DFrontImporter::ReadConfig(config_json);
             auto options = vsg::Options::create(vsgXchange::assimp::create(), vsgXchange::dds::create(), vsgXchange::stbi::create()); //using the assimp loader
@@ -678,16 +678,16 @@ int main(int argc, char **argv)
                 offlineGBufferStager->transferStagingDataFrom(offlineGBuffers[frame_index]);
                 offlineIlluminationBufferStager->transferStagingDataFrom(offlineIlluminations[frame_index]);
                 if (accumulator)
-                   accumulator->setDoubleMatrix(frame_index, cameraMatrices[frame_index], cameraMatrices[frame_index ? frame_index - 1 : frame_index]);
+                   accumulator->setCameraMatrices(frame_index, cameraMatrices[frame_index], cameraMatrices[frame_index ? frame_index - 1 : frame_index]);
             }
             else if (accumulator)
             {
-                DoubleMatrix a{}, b{};
+                CameraMatrices a{}, b{};
                 a.invView = lookAt->inverse();
                 a.invProj = perspective->inverse();
                 a.proj = perspective->transform();
                 b.view = rayTracingPushConstantsValue->value().prevView;
-                accumulator->setDoubleMatrix(rayTracingPushConstantsValue->value().frameNumber, a, b);
+                accumulator->setCameraMatrices(rayTracingPushConstantsValue->value().frameNumber, a, b);
             }
 
             viewer->update();

--- a/source/VulkanPBRT.cpp
+++ b/source/VulkanPBRT.cpp
@@ -421,7 +421,6 @@ int main(int argc, char **argv)
         {
             queryPool = vsg::QueryPool::create(); //standard init has 1 timestamp place
             queryPool->queryCount = 2;
-            queryPool->compile(imageLayoutCompile.context);
             auto resetQuery = vsg::ResetQueryPool::create(queryPool);
             auto write1 = vsg::WriteTimestamp::create(queryPool, 0, VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR);
             auto write2 = vsg::WriteTimestamp::create(queryPool, 1, VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR);
@@ -447,7 +446,6 @@ int main(int argc, char **argv)
         {
             queryPool = vsg::QueryPool::create(); //standard init has 1 timestamp place
             queryPool->queryCount = 2;
-            queryPool->compile(imageLayoutCompile.context);
             auto resetQuery = vsg::ResetQueryPool::create(queryPool);
             auto write1 = vsg::WriteTimestamp::create(queryPool, 0, VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR);
             auto write2 = vsg::WriteTimestamp::create(queryPool, 1, VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR);
@@ -708,7 +706,6 @@ int main(int argc, char **argv)
             viewer->present();
             if (queryPool)
             {
-                viewer->deviceWaitIdle();
                 auto results = queryPool->getResults();
                 static double running = 0;
                 static int count = 0;

--- a/source/buffers/GBuffer.cpp
+++ b/source/buffers/GBuffer.cpp
@@ -8,18 +8,18 @@ void GBuffer::updateDescriptor(vsg::BindDescriptorSet* descSet, const vsg::Bindi
 {
     vsg::DescriptorSetLayoutBindings& bindings = descSet->descriptorSet->setLayout->bindings;
     int depthInd = vsg::ShaderStage::getSetBindingIndex(bindingMap, "depthImage").second;
-    depth->dstBinding = depthInd;
+    auto depthBind = vsg::DescriptorImage::create(depth->imageInfoList, depthInd, 0, depth->descriptorType);
     int normalInd = vsg::ShaderStage::getSetBindingIndex(bindingMap, "normalImage").second;
-    normal->dstBinding = normalInd;
+    auto normalBind = vsg::DescriptorImage::create(normal->imageInfoList, normalInd, 0, normal->descriptorType);
     int materialInd = vsg::ShaderStage::getSetBindingIndex(bindingMap, "materialImage").second;
-    material->dstBinding = materialInd;
+    auto materialBind = vsg::DescriptorImage::create(material->imageInfoList, materialInd, 0, material->descriptorType);
     int albedoInd = vsg::ShaderStage::getSetBindingIndex(bindingMap, "albedoImage").second;
-    albedo->dstBinding = albedoInd;
+    auto albedoBind = vsg::DescriptorImage::create(albedo->imageInfoList, albedoInd, 0, albedo->descriptorType);
 
-    descSet->descriptorSet->descriptors.push_back(depth);
-    descSet->descriptorSet->descriptors.push_back(normal);
-    descSet->descriptorSet->descriptors.push_back(material);
-    descSet->descriptorSet->descriptors.push_back(albedo);
+    descSet->descriptorSet->descriptors.push_back(depthBind);
+    descSet->descriptorSet->descriptors.push_back(normalBind);
+    descSet->descriptorSet->descriptors.push_back(materialBind);
+    descSet->descriptorSet->descriptors.push_back(albedoBind);
 }
 void GBuffer::updateImageLayouts(vsg::Context& context)
 {

--- a/source/buffers/IlluminationBuffer.cpp
+++ b/source/buffers/IlluminationBuffer.cpp
@@ -260,7 +260,6 @@ IlluminationBufferDemodulatedFloat::IlluminationBufferDemodulatedFloat(uint32_t 
     this->width = width;
     this->height = height;
     illuminationBindings.push_back("illumination");
-    illuminationBindings.push_back("illuminationSquared");
     fillImages();
 }
 
@@ -278,22 +277,9 @@ void IlluminationBufferDemodulatedFloat::fillImages()
     auto imageView = vsg::ImageView::create(image, VK_IMAGE_ASPECT_COLOR_BIT);
     auto imageInfo = vsg::ImageInfo::create(vsg::ref_ptr<vsg::Sampler>{}, imageView, VK_IMAGE_LAYOUT_GENERAL);
     illuminationImages.push_back(vsg::DescriptorImage::create(imageInfo, 0, 0, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE));
-
-    image = vsg::Image::create();
-    image->imageType = VK_IMAGE_TYPE_2D;
-    image->format = VK_FORMAT_R32G32B32A32_SFLOAT;
-    image->extent.width = width;
-    image->extent.height = height;
-    image->extent.depth = 1;
-    image->mipLevels = 1;
-    image->arrayLayers = 1;
-    image->usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_STORAGE_BIT;
-    imageView = vsg::ImageView::create(image, VK_IMAGE_ASPECT_COLOR_BIT);
-    imageInfo = vsg::ImageInfo::create(vsg::ref_ptr<vsg::Sampler>{}, imageView, VK_IMAGE_LAYOUT_GENERAL);
-    illuminationImages.push_back(vsg::DescriptorImage::create(imageInfo, 0, 0, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE));
 }
 
-IlluminatonBufferFinalFloat::IlluminatonBufferFinalFloat(uint32_t width, uint32_t height) 
+IlluminationBufferFinalFloat::IlluminationBufferFinalFloat(uint32_t width, uint32_t height) 
 {
     this->width = width;
     this->height = height;
@@ -301,7 +287,7 @@ IlluminatonBufferFinalFloat::IlluminatonBufferFinalFloat(uint32_t width, uint32_
     fillImages();
 }
 
-void IlluminatonBufferFinalFloat::fillImages(){
+void IlluminationBufferFinalFloat::fillImages(){
     auto image = vsg::Image::create();
     image->imageType = VK_IMAGE_TYPE_2D;
     image->format = VK_FORMAT_R32G32B32A32_SFLOAT;

--- a/source/buffers/IlluminationBuffer.hpp
+++ b/source/buffers/IlluminationBuffer.hpp
@@ -62,9 +62,9 @@ public:
     void fillImages();
 };
 
-class IlluminatonBufferFinalFloat: public vsg::Inherit<IlluminationBuffer, IlluminatonBufferFinalFloat>{
+class IlluminationBufferFinalFloat: public vsg::Inherit<IlluminationBuffer, IlluminationBufferFinalFloat>{
 public:
-    IlluminatonBufferFinalFloat(uint32_t width, uint32_t height);
+    IlluminationBufferFinalFloat(uint32_t width, uint32_t height);
 
     void fillImages();
 };

--- a/source/io/RenderIO.cpp
+++ b/source/io/RenderIO.cpp
@@ -55,7 +55,7 @@ std::vector<vsg::ref_ptr<OfflineGBuffer>> GBufferIO::importGBufferDepth(const st
     return gBuffers;
 }
 
-std::vector<vsg::ref_ptr<OfflineGBuffer>> GBufferIO::importGBufferPosition(const std::string &positionFormat, const std::string &normalFormat, const std::string &materialFormat, const std::string &albedoFormat, const std::vector<DoubleMatrix> &matrices, int numFrames, int verbosity)
+std::vector<vsg::ref_ptr<OfflineGBuffer>> GBufferIO::importGBufferPosition(const std::string &positionFormat, const std::string &normalFormat, const std::string &materialFormat, const std::string &albedoFormat, const std::vector<CameraMatrices> &matrices, int numFrames, int verbosity)
 {
     if(verbosity > 0)
         std::cout << "Start loading GBuffer" << std::endl;
@@ -155,7 +155,7 @@ vsg::ref_ptr<vsg::Data> GBufferIO::compressAlbedo(vsg::ref_ptr<vsg::Data> in){
     return vsg::ubvec4Array2D::create(in->width(), in->height(), albedo, vsg::Data::Layout{VK_FORMAT_R8G8B8A8_UNORM});
 }
 
-bool GBufferIO::exportGBuffer(const std::string& positionFormat, const std::string& depthFormat, const std::string& normalFormat, const std::string& materialFormat, const std::string& albedoFormat, int numFrames, const OfflineGBuffers& gBuffers, const DoubleMatrices& matrices, int verbosity) 
+bool GBufferIO::exportGBuffer(const std::string& positionFormat, const std::string& depthFormat, const std::string& normalFormat, const std::string& materialFormat, const std::string& albedoFormat, int numFrames, const OfflineGBuffers& gBuffers, const CameraMatricesVec& matrices, int verbosity) 
 {
     if(verbosity > 0)
         std::cout << "Start exporting GBuffer" << std::endl;
@@ -254,7 +254,7 @@ vsg::ref_ptr<vsg::Data> GBufferIO::unormToFloat(vsg::ref_ptr<vsg::ubvec4Array2D>
     return vsg::vec4Array2D::create(array->width(), array->height(), res, vsg::Data::Layout{VK_FORMAT_R32G32B32A32_SFLOAT});
 }
 
-vsg::ref_ptr<vsg::Data> GBufferIO::depthToPosition(vsg::ref_ptr<vsg::floatArray2D> depths, const DoubleMatrix& matrix)
+vsg::ref_ptr<vsg::Data> GBufferIO::depthToPosition(vsg::ref_ptr<vsg::floatArray2D> depths, const CameraMatrices& matrix)
 {
     if(!depths) return {};
     if(!matrix.proj){
@@ -434,7 +434,7 @@ bool IlluminationBufferIO::exportIllumination(const std::string& illuminationFor
     return fine;
 }
 
-DoubleMatrices MatrixIO::importMatrices(const std::string &matrixPath)
+CameraMatricesVec MatrixIO::importMatrices(const std::string &matrixPath)
 {
     //TODO: temporary implementation to parse matrices from BMFRs dataset
     std::ifstream f(matrixPath);
@@ -443,7 +443,7 @@ DoubleMatrices MatrixIO::importMatrices(const std::string &matrixPath)
         return {};
     }
 
-    DoubleMatrices matrices;
+    CameraMatricesVec matrices;
 
     auto toMat4 = [](const nlohmann::json& json){
         vsg::mat4 ret;
@@ -492,7 +492,7 @@ DoubleMatrices MatrixIO::importMatrices(const std::string &matrixPath)
     return matrices;
 }
 
-bool MatrixIO::exportMatrices(const std::string &matrixPath, const DoubleMatrices& matrices)
+bool MatrixIO::exportMatrices(const std::string &matrixPath, const CameraMatricesVec& matrices)
 {
     std::ofstream f(matrixPath, std::ofstream::out);
     if (!f) {

--- a/source/io/RenderIO.hpp
+++ b/source/io/RenderIO.hpp
@@ -20,17 +20,17 @@ public:
 };
 
 // Matrices ------------------------------------------------------------------------
-class DoubleMatrix{
+class CameraMatrices{
 public:
     vsg::mat4 view, invView;    //if no projection matrix is available, the projection and view matricesa are combined in the view matrix
     std::optional<vsg::mat4> proj, invProj;
 };
-using DoubleMatrices = std::vector<DoubleMatrix>;
+using CameraMatricesVec = std::vector<CameraMatrices>;
 
 class MatrixIO{
 public:
-    static std::vector<DoubleMatrix> importMatrices(const std::string& matrixPath);
-    static bool exportMatrices(const std::string& matrixPath, const DoubleMatrices& matrices);
+    static std::vector<CameraMatrices> importMatrices(const std::string& matrixPath);
+    static bool exportMatrices(const std::string& matrixPath, const CameraMatricesVec& matrices);
 };
 
 // GBuffer --------------------------------------------------------------------------
@@ -53,14 +53,14 @@ using OfflineGBuffers = std::vector<vsg::ref_ptr<OfflineGBuffer>>;
 class GBufferIO{
 public:
     static OfflineGBuffers importGBufferDepth(const std::string& depthFormat, const std::string& normalFormat, const std::string& materialFormat, const std::string& albedoFormat, int numFrames, int verbosity = 1);
-    static OfflineGBuffers importGBufferPosition(const std::string& positionFormat, const std::string& normalFormat, const std::string& materialFormat, const std::string& albedoFormat, const std::vector<DoubleMatrix>& matrices, int numFrames, int verbosity = 1);
-    static bool exportGBuffer(const std::string& positionFormat, const std::string& depthFormat, const std::string& normalFormat, const std::string& materialFormat, const std::string& albedoFormat, int numFrames, const OfflineGBuffers& gBuffers, const DoubleMatrices& matrices, int verbosity = 1);
+    static OfflineGBuffers importGBufferPosition(const std::string& positionFormat, const std::string& normalFormat, const std::string& materialFormat, const std::string& albedoFormat, const std::vector<CameraMatrices>& matrices, int numFrames, int verbosity = 1);
+    static bool exportGBuffer(const std::string& positionFormat, const std::string& depthFormat, const std::string& normalFormat, const std::string& materialFormat, const std::string& albedoFormat, int numFrames, const OfflineGBuffers& gBuffers, const CameraMatricesVec& matrices, int verbosity = 1);
 private:
     static vsg::ref_ptr<vsg::Data> convertNormalToSpherical(vsg::ref_ptr<vsg::vec4Array2D> normals);
     static vsg::ref_ptr<vsg::Data> compressAlbedo(vsg::ref_ptr<vsg::Data> in);
     static vsg::ref_ptr<vsg::Data> sphericalToCartesian(vsg::ref_ptr<vsg::vec2Array2D> normals);
     static vsg::ref_ptr<vsg::Data> unormToFloat(vsg::ref_ptr<vsg::ubvec4Array2D> array);
-    static vsg::ref_ptr<vsg::Data> depthToPosition(vsg::ref_ptr<vsg::floatArray2D> depths, const DoubleMatrix& matrix);
+    static vsg::ref_ptr<vsg::Data> depthToPosition(vsg::ref_ptr<vsg::floatArray2D> depths, const CameraMatrices& matrix);
 };
 
 // IlluminationBuffer ---------------------------------------------------------------

--- a/source/renderModules/Accumulator.cpp
+++ b/source/renderModules/Accumulator.cpp
@@ -11,6 +11,9 @@ Accumulator::Accumulator(vsg::ref_ptr<GBuffer> gBuffer, vsg::ref_ptr<Illuminatio
     originalIllumination(illuminationBuffer)
 {
     auto computeStage = vsg::ShaderStage::read(VK_SHADER_STAGE_COMPUTE_BIT, "main", shaderPath);
+    if(!computeStage){
+        throw vsg::Exception{"Accumulator::create() could not open compute shader stage"};
+    }
     computeStage->specializationConstants = vsg::ShaderStage::SpecializationConstants{
         {0, vsg::intValue::create(workWidth)}, 
         {1, vsg::intValue::create(workHeight)}

--- a/source/renderModules/Accumulator.cpp
+++ b/source/renderModules/Accumulator.cpp
@@ -74,7 +74,7 @@ void Accumulator::addDispatchToCommandGraph(vsg::ref_ptr<vsg::Commands> commandG
     commandGraph->addChild(pipelineBarrier);
 }
 
-void Accumulator::setDoubleMatrix(int frameIndex, const DoubleMatrix& cur, const DoubleMatrix& prev)
+void Accumulator::setCameraMatrices(int frameIndex, const CameraMatrices& cur, const CameraMatrices& prev)
 {
     if(_separateMatrices){
         if(!cur.proj || !cur.invProj) throw vsg::Exception{"Accumulator::setDoubleMatrix(...) Accumulator was created with separateMatrices = true, but DubleMatrix is missing seperate matrices"};

--- a/source/renderModules/Accumulator.cpp
+++ b/source/renderModules/Accumulator.cpp
@@ -64,11 +64,14 @@ void Accumulator::updateImageLayouts(vsg::Context& context)
 
 void Accumulator::addDispatchToCommandGraph(vsg::ref_ptr<vsg::Commands> commandGraph) 
 {
+    auto pipelineBarrier = vsg::PipelineBarrier::create(VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+        0);
     commandGraph->addChild(bindPipeline);
     commandGraph->addChild(bindDescriptorSet);
     commandGraph->addChild(pushConstants);
     commandGraph->addChild(vsg::Dispatch::create(uint32_t(ceil(float(width) / float(workWidth))), uint32_t(ceil(float(height) / float(workHeight))),
                                                  1));
+    commandGraph->addChild(pipelineBarrier);
 }
 
 void Accumulator::setDoubleMatrix(int frameIndex, const DoubleMatrix& cur, const DoubleMatrix& prev)

--- a/source/renderModules/Accumulator.hpp
+++ b/source/renderModules/Accumulator.hpp
@@ -38,7 +38,6 @@ private:
     int workWidth, workHeight;
     vsg::ref_ptr<GBuffer> gBuffer;
     vsg::ref_ptr<IlluminationBuffer> originalIllumination;
-    DoubleMatrices matrices;
     vsg::ref_ptr<vsg::BindComputePipeline> bindPipeline;
     vsg::ref_ptr<vsg::BindDescriptorSet> bindDescriptorSet;
     vsg::ref_ptr<vsg::PushConstants> pushConstants;

--- a/source/renderModules/Accumulator.hpp
+++ b/source/renderModules/Accumulator.hpp
@@ -11,13 +11,13 @@ private:
     int width, height;
 public:
     // Always takes the first image in the illumination buffer and accumulates it
-    Accumulator(vsg::ref_ptr<GBuffer> gBuffer, vsg::ref_ptr<IlluminationBuffer> illuminationBuffer, DoubleMatrices &matrices, int workWidth = 16, int workHeight = 16);
+    Accumulator(vsg::ref_ptr<GBuffer> gBuffer, vsg::ref_ptr<IlluminationBuffer> illuminationBuffer, bool separateMatrices, int workWidth = 16, int workHeight = 16);
 
     void compileImages(vsg::Context &context);
     void updateImageLayouts(vsg::Context &context);
     void addDispatchToCommandGraph(vsg::ref_ptr<vsg::Commands> commandGraph);
     // Frameindex is needed to upload the correct matrix
-    void setFrameIndex(int frame);
+    void setDoubleMatrix(int frameIndex, const DoubleMatrix& cur, const DoubleMatrix& prev);
 
     vsg::ref_ptr<IlluminationBuffer> accumulatedIllumination;
     vsg::ref_ptr<AccumulationBuffer> accumulationBuffer;
@@ -34,14 +34,14 @@ private:
     public:
         PCValue(){}
     };
-    std::string shaderPath = "shaders/accumulator.comp.spv";
+    std::string shaderPath = "shaders/accumulator.comp";    //normal glsl file has to be loaded as the shader has to be adopted to separateMatrices style
     int workWidth, workHeight;
     vsg::ref_ptr<GBuffer> gBuffer;
     vsg::ref_ptr<IlluminationBuffer> originalIllumination;
     DoubleMatrices matrices;
-    int frameIndex = 0;
     vsg::ref_ptr<vsg::BindComputePipeline> bindPipeline;
     vsg::ref_ptr<vsg::BindDescriptorSet> bindDescriptorSet;
     vsg::ref_ptr<vsg::PushConstants> pushConstants;
     vsg::ref_ptr<PCValue> pushConstantsValue;
+    bool _separateMatrices;
 };

--- a/source/renderModules/Accumulator.hpp
+++ b/source/renderModules/Accumulator.hpp
@@ -17,7 +17,7 @@ public:
     void updateImageLayouts(vsg::Context &context);
     void addDispatchToCommandGraph(vsg::ref_ptr<vsg::Commands> commandGraph);
     // Frameindex is needed to upload the correct matrix
-    void setDoubleMatrix(int frameIndex, const DoubleMatrix& cur, const DoubleMatrix& prev);
+    void setCameraMatrices(int frameIndex, const CameraMatrices& cur, const CameraMatrices& prev);
 
     vsg::ref_ptr<IlluminationBuffer> accumulatedIllumination;
     vsg::ref_ptr<AccumulationBuffer> accumulationBuffer;

--- a/source/renderModules/PBRTPipeline.cpp
+++ b/source/renderModules/PBRTPipeline.cpp
@@ -59,6 +59,8 @@ void PBRTPipeline::updateImageLayouts(vsg::Context &context)
 }
 void PBRTPipeline::addTraceRaysToCommandGraph(vsg::ref_ptr<vsg::Commands> commandGraph, vsg::ref_ptr<vsg::PushConstants> pushConstants)
 {
+    auto pipelineBarrier = vsg::PipelineBarrier::create(VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR, VK_PIPELINE_STAGE_TRANSFER_BIT | VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+        VK_DEPENDENCY_DEVICE_GROUP_BIT);
     commandGraph->addChild(bindRayTracingPipeline);
     commandGraph->addChild(bindRayTracingDescriptorSet);
     commandGraph->addChild(pushConstants);
@@ -68,6 +70,7 @@ void PBRTPipeline::addTraceRaysToCommandGraph(vsg::ref_ptr<vsg::Commands> comman
     traceRays->height = height;
     traceRays->depth = 1;
     commandGraph->addChild(traceRays);
+    commandGraph->addChild(pipelineBarrier);
 }
 vsg::ref_ptr<IlluminationBuffer> PBRTPipeline::getIlluminationBuffer() const
 {

--- a/source/renderModules/PBRTPipeline.cpp
+++ b/source/renderModules/PBRTPipeline.cpp
@@ -167,9 +167,12 @@ vsg::ref_ptr<vsg::ShaderStage> PBRTPipeline::setupRaygenShader(std::string rayge
     }
     else
     {
-        if (illuminationBuffer.cast<IlluminatonBufferFinalFloat>())
+        if (illuminationBuffer.cast<IlluminationBufferFinalFloat>())
         {
             defines.push_back("FINAL_IMAGE");
+        }
+        else if(illuminationBuffer.cast<IlluminationBufferDemodulatedFloat>()){
+            defines.push_back("DEMOD_ILLUMINATION_FLOAT");
         }
         else if (illuminationBuffer.cast<IlluminationBufferFinalDirIndir>())
         {

--- a/source/renderModules/PBRTPipeline.cpp
+++ b/source/renderModules/PBRTPipeline.cpp
@@ -21,12 +21,11 @@ namespace
     };
 }
 
-PBRTPipeline::PBRTPipeline(vsg::ref_ptr<vsg::Node> scene, vsg::ref_ptr<GBuffer> gBuffer, vsg::ref_ptr<AccumulationBuffer> accumulationBuffer,
+PBRTPipeline::PBRTPipeline(vsg::ref_ptr<vsg::Node> scene, vsg::ref_ptr<GBuffer> gBuffer,
                  vsg::ref_ptr<IlluminationBuffer> illuminationBuffer, bool writeGBuffer, RayTracingRayOrigin rayTracingRayOrigin) : 
     width(illuminationBuffer->illuminationImages[0]->imageInfoList[0]->imageView->image->extent.width), 
     height(illuminationBuffer->illuminationImages[0]->imageInfoList[0]->imageView->image->extent.height), 
     maxRecursionDepth(2), 
-    accumulationBuffer(accumulationBuffer),
     illuminationBuffer(illuminationBuffer),
     gBuffer(gBuffer)
 {
@@ -155,8 +154,6 @@ void PBRTPipeline::setupPipeline(vsg::Node *scene, bool useExternalGbuffer)
     illuminationBuffer->updateDescriptor(bindRayTracingDescriptorSet, bindingMap);
     if (gBuffer)
         gBuffer->updateDescriptor(bindRayTracingDescriptorSet, bindingMap);
-    if (accumulationBuffer)
-        accumulationBuffer->updateDescriptor(bindRayTracingDescriptorSet, bindingMap);
 }
 vsg::ref_ptr<vsg::ShaderStage> PBRTPipeline::setupRaygenShader(std::string raygenPath, bool useExternalGBuffer)
 {
@@ -181,17 +178,6 @@ vsg::ref_ptr<vsg::ShaderStage> PBRTPipeline::setupRaygenShader(std::string rayge
         {
             // TODO:
         }
-        else if (illuminationBuffer.cast<IlluminationBufferFinalDemodulated>())
-        {
-            defines.push_back("FINAL_IMAGE");
-            defines.push_back("DEMOD_ILLUMINATION");
-            defines.push_back("DEMOD_ILLUMINATION_SQUARED");
-        }
-        else if (illuminationBuffer.cast<IlluminationBufferDemodulated>())
-        {
-            defines.push_back("DEMOD_ILLUMINATION");
-            defines.push_back("DEMOD_ILLUMINATION_SQUARED");
-        }
         else
         {
             throw vsg::Exception{"Error: PBRTPipeline::setupRaygenShader(...) Illumination buffer not supported."};
@@ -199,8 +185,6 @@ vsg::ref_ptr<vsg::ShaderStage> PBRTPipeline::setupRaygenShader(std::string rayge
     }
     if (gBuffer)
         defines.push_back("GBUFFER");
-    if (accumulationBuffer)
-        defines.push_back("PREV_GBUFFER");
 
     switch(lightSamplingMethod){
         case LightSamplingMethod::SampleSurfaceStrength:

--- a/source/renderModules/PBRTPipeline.hpp
+++ b/source/renderModules/PBRTPipeline.hpp
@@ -19,7 +19,7 @@ enum class RayTracingRayOrigin
 class PBRTPipeline : public vsg::Inherit<vsg::Object, PBRTPipeline>
 {
 public:
-    PBRTPipeline(vsg::ref_ptr<vsg::Node> scene, vsg::ref_ptr<GBuffer> gBuffer, vsg::ref_ptr<AccumulationBuffer> accumulationBuffer,
+    PBRTPipeline(vsg::ref_ptr<vsg::Node> scene, vsg::ref_ptr<GBuffer> gBuffer,
                  vsg::ref_ptr<IlluminationBuffer> illuminationBuffer, bool writeGBuffer, RayTracingRayOrigin rayTracingRayOrigin);
 
     void setTlas(vsg::ref_ptr<vsg::AccelerationStructure> as);
@@ -41,7 +41,6 @@ private:
 
     // TODO: add buffers here
     vsg::ref_ptr<GBuffer> gBuffer;
-    vsg::ref_ptr<AccumulationBuffer> accumulationBuffer;
     vsg::ref_ptr<IlluminationBuffer> illuminationBuffer;
 
     //resources which have to be added as childs to a scenegraph for rendering

--- a/source/renderModules/denoisers/BFR.cpp
+++ b/source/renderModules/denoisers/BFR.cpp
@@ -124,7 +124,7 @@ void BFR::addDispatchToCommandGraph(vsg::ref_ptr<vsg::Commands> commandGraph, vs
     commandGraph->addChild(bindBfrPipeline);
     commandGraph->addChild(bindDescriptorSet);
     commandGraph->addChild(pushConstants);
-    commandGraph->addChild(vsg::Dispatch::create((width / workWidth + 1), (height / workHeight + 1), 1));
+    commandGraph->addChild(vsg::Dispatch::create((width / workWidth + 1), (height / workHeight + 2), 1));
     auto pipelineBarrier = vsg::PipelineBarrier::create(VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
         VK_DEPENDENCY_BY_REGION_BIT);
     commandGraph->addChild(pipelineBarrier); //barrier to wait for completion of denoising before taa is applied

--- a/source/renderModules/denoisers/BFR.cpp
+++ b/source/renderModules/denoisers/BFR.cpp
@@ -124,7 +124,7 @@ void BFR::addDispatchToCommandGraph(vsg::ref_ptr<vsg::Commands> commandGraph, vs
     commandGraph->addChild(bindBfrPipeline);
     commandGraph->addChild(bindDescriptorSet);
     commandGraph->addChild(pushConstants);
-    commandGraph->addChild(vsg::Dispatch::create((width / workWidth + 1), (height / workHeight + 2), 1));
+    commandGraph->addChild(vsg::Dispatch::create((width / workWidth + 2), (height / workHeight + 2), 1));
     auto pipelineBarrier = vsg::PipelineBarrier::create(VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
         VK_DEPENDENCY_BY_REGION_BIT);
     commandGraph->addChild(pipelineBarrier); //barrier to wait for completion of denoising before taa is applied

--- a/source/renderModules/denoisers/BMFR.cpp
+++ b/source/renderModules/denoisers/BMFR.cpp
@@ -10,7 +10,7 @@ BMFR::BMFR(uint32_t width, uint32_t height, uint32_t workWidth, uint32_t workHei
     workHeight(workHeight),
     fittingKernel(fittingKernel),
     widthPadded((width / workWidth + 1) * workWidth),
-    heightPadded((height / workHeight + 1) * workHeight),
+    heightPadded((height / workHeight + 2) * workHeight),
     gBuffer(gBuffer),
     sampler(vsg::Sampler::create())
 {
@@ -196,7 +196,7 @@ void BMFR::updateImageLayouts(vsg::Context& context)
 void BMFR::addDispatchToCommandGraph(vsg::ref_ptr<vsg::Commands> commandGraph, vsg::ref_ptr<vsg::PushConstants> pushConstants)
 {
     auto pipelineBarrier = vsg::PipelineBarrier::create(VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
-        VK_DEPENDENCY_BY_REGION_BIT);
+        0);
     uint32_t dispatchX = widthPadded / workWidth, dispatchY = heightPadded / workHeight;
     // pre pipeline
     commandGraph->addChild(bindPrePipeline);

--- a/source/renderModules/denoisers/BMFR.cpp
+++ b/source/renderModules/denoisers/BMFR.cpp
@@ -9,7 +9,7 @@ BMFR::BMFR(uint32_t width, uint32_t height, uint32_t workWidth, uint32_t workHei
     workWidth(workWidth),
     workHeight(workHeight),
     fittingKernel(fittingKernel),
-    widthPadded((width / workWidth + 1) * workWidth),
+    widthPadded((width / workWidth + 2) * workWidth),
     heightPadded((height / workHeight + 2) * workHeight),
     gBuffer(gBuffer),
     sampler(vsg::Sampler::create())

--- a/source/scene/RayTracingVisitor.cpp
+++ b/source/scene/RayTracingVisitor.cpp
@@ -300,8 +300,9 @@ void RayTracingSceneDescriptorCreationVisitor::apply(vsg::BindDescriptorSet& bds
             texture = vsg::DescriptorImage::create(d->imageInfoList, 11, _specular.size());
             _specular.push_back(texture);
             setTextures.insert(11);
+            break;
         default:
-            std::cout << "Unkown texture binding. Could not properly detect material" << std::endl;
+            std::cout << "Unkown texture binding: " << descriptor->dstBinding << ". Could not properly detect material" << std::endl;
         }
     }
 


### PR DESCRIPTION
Adds vsg query pool classes for gpu benchmarking.
Tested the runtime of accumulation in the raygen shader:
- In the raygen shader: 0.8 ms
- In extra compute shader: 0.2 ms

Before final pull request is made, the accumulation code in the raygen shader should be deleted.

Also a few small bugfixes for the raymiss shader are included which caused fireflies.